### PR TITLE
first try to enable java8 streams for tensors

### DIFF
--- a/src/java/org/tensorics/core/lang/Tensorics.java
+++ b/src/java/org/tensorics/core/lang/Tensorics.java
@@ -29,6 +29,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import org.tensorics.core.math.ExtendedField;
 import org.tensorics.core.quantity.ImmutableQuantifiedValue;
@@ -47,6 +48,7 @@ import org.tensorics.core.tensor.lang.QuantityTensors;
 import org.tensorics.core.tensor.lang.TensorStructurals;
 import org.tensorics.core.tensor.operations.FunctionTensorCreationOperation;
 import org.tensorics.core.tensor.operations.SingleValueTensorCreationOperation;
+import org.tensorics.core.tensor.stream.TensorStreams;
 import org.tensorics.core.tensorbacked.Tensorbacked;
 import org.tensorics.core.tensorbacked.TensorbackedBuilder;
 import org.tensorics.core.tensorbacked.Tensorbackeds;
@@ -57,7 +59,6 @@ import org.tensorics.core.units.Unit;
 
 import com.google.common.base.Optional;
 
-
 /**
  * The main entry point for constructing and structural manipulation of tensorics. If mathematical operations are
  * required, then you should either inherit from {@link TensoricSupport} (or one of its convenience implementations) or
@@ -65,10 +66,10 @@ import com.google.common.base.Optional;
  * <p>
  * Additional utilities for supporting classes can be found in the corresponding utility classes. E.g.
  * <ul>
- * <li> {@link org.tensorics.core.tensor.Positions}
- * <li> {@link org.tensorics.core.tensor.Shapes}
- * <li> {@link QuantityTensors}
- * <li> {@link Tensorbackeds}
+ * <li>{@link org.tensorics.core.tensor.Positions}
+ * <li>{@link org.tensorics.core.tensor.Shapes}
+ * <li>{@link QuantityTensors}
+ * <li>{@link Tensorbackeds}
  * </ul>
  * 
  * @author kfuchsbe, agorzaws, mihostet
@@ -136,6 +137,13 @@ public final class Tensorics {
      */
     public static <T> Tensor<T> fromMap(Set<? extends Class<?>> dimensions, Map<Position, T> map) {
         return ImmutableTensor.fromMap(dimensions, map);
+    }
+
+    /**
+     * @see ImmutableTensor#fromMap(Set, Map)
+     */
+    public static <T> Tensor<T> fromMap(Map<Position, T> map) {
+        return ImmutableTensor.fromMap(map);
     }
 
     /**
@@ -333,7 +341,8 @@ public final class Tensorics {
         return TensorStructurals.transformScalars(tensor, function);
     }
 
-    public static final Tensor<QuantifiedValue<Double>> zeroDimensionalOf(double value, javax.measure.unit.Unit<?> unit) {
+    public static final Tensor<QuantifiedValue<Double>> zeroDimensionalOf(double value,
+            javax.measure.unit.Unit<?> unit) {
         QuantifiedValue<Double> quantity = quantityOf(value, unit);
         return zeroDimensionalOf(quantity);
     }
@@ -400,4 +409,17 @@ public final class Tensorics {
         return Tensorbackeds.setContext(tensorbacked, context);
     }
 
+    /**
+     * @see TensorStreams#tensorEntryStream(Tensor)
+     */
+    public static <S> Stream<Map.Entry<Position, S>> stream(Tensor<S> tensor) {
+        return TensorStreams.tensorEntryStream(tensor);
+    }
+
+    /**
+     * @see TensorStreams#tensorEntryStream(Tensor)
+     */
+    public static <S> Stream<Map.Entry<Position, S>> stream(Tensorbacked<S> tensorBacked) {
+        return TensorStreams.tensorEntryStream(tensorBacked.tensor());
+    }
 }

--- a/src/java/org/tensorics/core/tensor/ImmutableTensor.java
+++ b/src/java/org/tensorics/core/tensor/ImmutableTensor.java
@@ -36,316 +36,326 @@ import com.google.common.collect.ImmutableMultiset;
 /**
  * Default Implementation of {@link Tensor}.
  * <p>
- * By constraint of creation it holds a map of {@link Position} of certain type
- * to values of type T, such that ALL Positions contains the same number and
- * type of coordinates. Number and type of coordinates can be accessed and
+ * By constraint of creation it holds a map of {@link Position} of certain type to values of type T, such that ALL
+ * Positions contains the same number and type of coordinates. Number and type of coordinates can be accessed and
  * explored via {@link Shape}.
  * <p>
- * There is a special type of Tensor that has ZERO dimensiality. Can be obtained
- * via factory method.
+ * There is a special type of Tensor that has ZERO dimensiality. Can be obtained via factory method.
  * <p>
  * {@link ImmutableTensor} is immutable.
  * <p>
  * The toString() method does not print all the tensor entries.
  * 
  * @author agorzaws, kfuchsbe
- * @param <T>
- *            type of values in Tensor.
+ * @param <T> type of values in Tensor.
  */
 @SuppressWarnings({ "PMD.CyclomaticComplexity", "PMD.TooManyMethods" })
 public class ImmutableTensor<T> implements Tensor<T>, Serializable {
 
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-	private static final int TOSTRING_BUFFER_SIZE = 64;
-	private static final int POSITION_TO_DISPLAY = 10;
-	private final Map<Position, T> entries;
-	private final Shape shape; // NOSONAR
-	private final Context context; // NOSONAR
+    private static final int TOSTRING_BUFFER_SIZE = 64;
+    private static final int POSITION_TO_DISPLAY = 10;
+    private final Map<Position, T> entries;
+    private final Shape shape; // NOSONAR
+    private final Context context; // NOSONAR
 
-	/**
-	 * Package-private constructor to be called from builder
-	 * 
-	 * @param builder
-	 *            to be used when {@link ImmutableTensor} is created.
-	 */
-	ImmutableTensor(Builder<T> builder) {
-		this.entries = builder.createEntriesMap();
-		this.shape = Shape.viewOf(builder.getDimensions(), this.entries.keySet());
-		this.context = builder.getContext();
-	}
+    /**
+     * Package-private constructor to be called from builder
+     * 
+     * @param builder to be used when {@link ImmutableTensor} is created.
+     */
+    ImmutableTensor(Builder<T> builder) {
+        this.entries = builder.createEntriesMap();
+        this.shape = Shape.viewOf(builder.getDimensions(), this.entries.keySet());
+        this.context = builder.getContext();
+    }
 
-	/**
-	 * Returns a builder for an {@link ImmutableTensor}. As argument it takes
-	 * set of class of coordinates which represent the dimensions of the tensor.
-	 * 
-	 * @param dimensions
-	 *            a set of classes that can later be used as coordinates for the
-	 *            tensor entries.
-	 * @return a builder for {@link ImmutableTensor}
-	 * @param <T>
-	 *            type of values in Tensor.
-	 */
-	public static final <T> Builder<T> builder(Set<? extends Class<?>> dimensions) {
-		return new Builder<T>(dimensions);
-	}
+    /**
+     * Returns a builder for an {@link ImmutableTensor}. As argument it takes set of class of coordinates which
+     * represent the dimensions of the tensor.
+     * 
+     * @param dimensions a set of classes that can later be used as coordinates for the tensor entries.
+     * @return a builder for {@link ImmutableTensor}
+     * @param <T> type of values in Tensor.
+     */
+    public static final <T> Builder<T> builder(Set<? extends Class<?>> dimensions) {
+        return new Builder<T>(dimensions);
+    }
 
-	/**
-	 * Returns a builder for an {@link ImmutableTensor}. The dimensions (classes
-	 * of coordinates) of the future tensor have to be given as arguments here.
-	 * 
-	 * @param dimensions
-	 *            the dimensions of the tensor to create
-	 * @return a builder for an immutable tensor
-	 * @param <T>
-	 *            the type of values of the tensor
-	 */
-	public static final <T> Builder<T> builder(Class<?>... dimensions) {
-		return builder(Coordinates.requireValidDimensions(ImmutableMultiset.copyOf(dimensions)));
-	}
+    /**
+     * Returns a builder for an {@link ImmutableTensor}. The dimensions (classes of coordinates) of the future tensor
+     * have to be given as arguments here.
+     * 
+     * @param dimensions the dimensions of the tensor to create
+     * @return a builder for an immutable tensor
+     * @param <T> the type of values of the tensor
+     */
+    public static final <T> Builder<T> builder(Class<?>... dimensions) {
+        return builder(Coordinates.requireValidDimensions(ImmutableMultiset.copyOf(dimensions)));
+    }
 
-	/**
-	 * Creates a tensor from the given map, where the map has to contain the
-	 * positions as keys and the values as values.
-	 * 
-	 * @param dimensions
-	 *            the desired dimensions of the tensor. This has to be
-	 *            consistent with the position - keys in the map.
-	 * @param map
-	 *            the map from which to construct a tensor
-	 * @return a new immutable tensor
-	 */
-	public static final <T> Tensor<T> fromMap(Set<? extends Class<?>> dimensions, Map<Position, T> map) {
-		Builder<T> builder = builder(dimensions);
-		builder.putAllMap(map);
-		return builder.build();
-	}
+    /**
+     * Creates a tensor from the given map, where the map has to contain the positions as keys and the values as values.
+     * 
+     * @param dimensions the desired dimensions of the tensor. This has to be consistent with the position - keys in the
+     *            map.
+     * @param map the map from which to construct a tensor
+     * @return a new immutable tensor
+     */
+    public static final <T> Tensor<T> fromMap(Set<? extends Class<?>> dimensions, Map<Position, T> map) {
+        Builder<T> builder = builder(dimensions);
+        builder.putAllMap(map);
+        return builder.build();
+    }
 
-	/**
-	 * Returns the builder that can create special tensor of dimension size
-	 * equal ZERO.
-	 * 
-	 * @param value
-	 *            to be used.
-	 * @return a builder for {@link ImmutableTensor}
-	 * @param <T>
-	 *            type of values in Tensor.
-	 */
-	public static final <T> Tensor<T> zeroDimensionalOf(T value) {
-		Builder<T> builder = builder(Collections.<Class<?>> emptySet());
-		builder.at(Position.empty()).put(value);
-		return builder.build();
-	}
+    /**
+     * Creates a tensor from the given map, where the map has to contain the positions as keys and the values as values.
+     * The dimensions of the tensors are automatically derived from the positions in the map. If they are inconsistent,
+     * this method throws; if the map is empty, an empty zero dimensional tensor is returned.
+     * 
+     * @param map the map from which to construct a tensor
+     * @return a new immutable tensor
+     */
+    public static final <T> Tensor<T> fromMap(Map<Position, T> map) {
+        if (map.isEmpty()) {
+            return zeroDimensionalEmptyTensor();
+        } else {
+            return fromMap(extractDimensionsAndEnsureConsistency(map), map);
+        }
+    }
 
-	/**
-	 * Creates an immutable copy of the given tensor.
-	 * 
-	 * @param tensor
-	 *            the tensor whose element to copy
-	 * @return new immutable Tensor
-	 */
-	public static final <T> Tensor<T> copyOf(Tensor<T> tensor) {
-		Builder<T> builder = builder(tensor.shape().dimensionSet());
-		builder.putAllMap(tensor.asMap());
-		builder.setTensorContext(tensor.context());
-		return builder.build();
-	}
+    private static <T> Set<Class<?>> extractDimensionsAndEnsureConsistency(Map<Position, T> data) {
+        Position anyPosition = data.keySet().iterator().next();
+        boolean sameDim = data.keySet().stream().map(Position::dimensionSet).allMatch(anyPosition::isConsistentWith);
+        if (!sameDim) {
+            throw new IllegalArgumentException(
+                    "For creating a Tensor from the map, all the positions must have the same dimensions");
+        }
+        return anyPosition.dimensionSet();
+    }
 
-	/**
-	 * Returns a builder for an {@link ImmutableTensor} which is initiliased
-	 * with the given {@link ImmutableTensor}.
-	 * 
-	 * @param tensor
-	 *            a Tensor with which the {@link Builder} is initialized
-	 * @return a {@link Builder} for an {@link ImmutableTensor}
-	 * @param <T>
-	 *            type of values in Tensor.
-	 */
-	public static <T> Builder<T> builderFrom(Tensor<T> tensor) {
-		Builder<T> builder = builder(tensor.shape().dimensionSet());
-		builder.putAllMap(tensor.asMap());
-		return builder;
-	}
+    private static <T> Tensor<T> zeroDimensionalEmptyTensor() {
+        Builder<T> builder = builder(Collections.<Class<?>> emptySet());
+        return builder.build();
+    }
 
-	@Override
-	public T get(Position position) {
-		return findValueOrThrow(position);
-	}
+    /**
+     * Returns the builder that can create special tensor of dimension size equal ZERO.
+     * 
+     * @param value to be used.
+     * @return a builder for {@link ImmutableTensor}
+     * @param <T> type of values in Tensor.
+     */
+    public static final <T> Tensor<T> zeroDimensionalOf(T value) {
+        Builder<T> builder = builder(Collections.<Class<?>> emptySet());
+        builder.at(Position.empty()).put(value);
+        return builder.build();
+    }
 
-	@Override
-	public Context context() {
-		return context;
-	}
+    /**
+     * Creates an immutable copy of the given tensor.
+     * 
+     * @param tensor the tensor whose element to copy
+     * @return new immutable Tensor
+     */
+    public static final <T> Tensor<T> copyOf(Tensor<T> tensor) {
+        Builder<T> builder = builder(tensor.shape().dimensionSet());
+        builder.putAllMap(tensor.asMap());
+        builder.setTensorContext(tensor.context());
+        return builder.build();
+    }
 
-	@Override
-	@Deprecated
-	public Set<Tensor.Entry<T>> entrySet() {
-		Set<Tensor.Entry<T>> toReturn = new HashSet<>();
-		for (java.util.Map.Entry<Position, T> one : entries.entrySet()) {
-			toReturn.add(new ImmutableEntry<>(one.getKey(), one.getValue()));
-		}
-		return toReturn;
-	}
+    /**
+     * Returns a builder for an {@link ImmutableTensor} which is initiliased with the given {@link ImmutableTensor}.
+     * 
+     * @param tensor a Tensor with which the {@link Builder} is initialized
+     * @return a {@link Builder} for an {@link ImmutableTensor}
+     * @param <T> type of values in Tensor.
+     */
+    public static <T> Builder<T> builderFrom(Tensor<T> tensor) {
+        Builder<T> builder = builder(tensor.shape().dimensionSet());
+        builder.putAllMap(tensor.asMap());
+        return builder;
+    }
 
-	@Override
-	public Map<Position, T> asMap() {
-		ImmutableMap.Builder<Position, T> builder = ImmutableMap.builder();
-		builder.putAll(entries);
-		return builder.build();
-	}
+    @Override
+    public T get(Position position) {
+        return findValueOrThrow(position);
+    }
 
-	@Override
-	@SafeVarargs
-	public final T get(Object... coordinates) {
-		return get(Position.of(coordinates));
-	}
+    @Override
+    public Context context() {
+        return context;
+    }
 
-	@Override
-	public Shape shape() {
-		return this.shape;
-	}
+    @Override
+    @Deprecated
+    public Set<Tensor.Entry<T>> entrySet() {
+        Set<Tensor.Entry<T>> toReturn = new HashSet<>();
+        for (java.util.Map.Entry<Position, T> one : entries.entrySet()) {
+            toReturn.add(new ImmutableEntry<>(one.getKey(), one.getValue()));
+        }
+        return toReturn;
+    }
 
-	private T findValueOrThrow(Position position) {
-		T entry = findEntryOrNull(position);
-		if (entry == null) {
-			String message = "Entry for position '" + position + "' is not contained in this tensor.";
-			Set<Class<?>> tensorDimensions = this.shape.dimensionSet();
-			Set<Class<?>> positionDimensions = position.dimensionSet();
-			if (tensorDimensions.equals(positionDimensions)) {
-				throw new NoSuchElementException(message);
-			} else {
-				message += "\nThe dimensions of the tensor (" + tensorDimensions
-						+ ") do not match the dimensions of the requested position (" + positionDimensions + ").";
-				throw new IllegalArgumentException(message);
-			}
-		}
-		return entry;
-	}
+    @Override
+    public Map<Position, T> asMap() {
+        /* the internal map is already immutable and does not need to be copied */
+        return entries;
+    }
 
-	private T findEntryOrNull(Position position) {
-		return this.entries.get(position);
-	}
+    @Override
+    @SafeVarargs
+    public final T get(Object... coordinates) {
+        return get(Position.of(coordinates));
+    }
 
-	/**
-	 * A builder for an immutable tensor.
-	 * 
-	 * @author kfuchsbe
-	 * @param <S>
-	 *            the type of the values to be added
-	 */
-	public static final class Builder<S> extends AbstractTensorBuilder<S> {
+    @Override
+    public Shape shape() {
+        return this.shape;
+    }
 
-		private final Map<Position, S> entries = new HashMap<>();
+    private T findValueOrThrow(Position position) {
+        T entry = findEntryOrNull(position);
+        if (entry == null) {
+            String message = "Entry for position '" + position + "' is not contained in this tensor.";
+            Set<Class<?>> tensorDimensions = this.shape.dimensionSet();
+            Set<Class<?>> positionDimensions = position.dimensionSet();
+            if (tensorDimensions.equals(positionDimensions)) {
+                throw new NoSuchElementException(message);
+            } else {
+                message += "\nThe dimensions of the tensor (" + tensorDimensions
+                        + ") do not match the dimensions of the requested position (" + positionDimensions + ").";
+                throw new IllegalArgumentException(message);
+            }
+        }
+        return entry;
+    }
 
-		Builder(Set<? extends Class<?>> dimensions) {
-			super(dimensions);
-		}
+    private T findEntryOrNull(Position position) {
+        return this.entries.get(position);
+    }
 
-		/**
-		 * Builds the entries map as an {@link ImmutableMap}.
-		 * 
-		 * @return
-		 */
-		public Map<Position, S> createEntriesMap() {
-			return ImmutableMap.<Position, S> builder().putAll(entries).build();
-		}
+    /**
+     * A builder for an immutable tensor.
+     * 
+     * @author kfuchsbe
+     * @param <S> the type of the values to be added
+     */
+    public static final class Builder<S> extends AbstractTensorBuilder<S> {
 
-		/**
-		 * Builds an {@link ImmutableTensor} from all elements put before.
-		 * 
-		 * @return an {@link ImmutableTensor}.
-		 */
-		@Override
-		public ImmutableTensor<S> build() {
-			return new ImmutableTensor<S>(this);
-		}
+        private final Map<Position, S> entries = new HashMap<>();
 
-		@Override
-		protected void putItAt(S value, Position position) {
-			this.entries.put(position, value);
-		}
+        Builder(Set<? extends Class<?>> dimensions) {
+            super(dimensions);
+        }
 
-		@Override
-		public void putAllMap(Map<Position, S> newEntries) {
-			this.entries.putAll(newEntries);
-		}
+        /**
+         * Builds the entries map as an {@link ImmutableMap}.
+         * 
+         * @return
+         */
+        public Map<Position, S> createEntriesMap() {
+            return ImmutableMap.<Position, S> builder().putAll(entries).build();
+        }
 
-		@Override
-		public void removeAt(Position position) {
-			entries.remove(position);
-		}
+        /**
+         * Builds an {@link ImmutableTensor} from all elements put before.
+         * 
+         * @return an {@link ImmutableTensor}.
+         */
+        @Override
+        public ImmutableTensor<S> build() {
+            return new ImmutableTensor<S>(this);
+        }
 
-		@Override
-		public void put(java.util.Map.Entry<Position, S> entry) {
-			this.putAt(entry.getValue(), entry.getKey());
-		}
+        @Override
+        protected void putItAt(S value, Position position) {
+            this.entries.put(position, value);
+        }
 
-		@Override
-		public void putAll(Tensor<S> tensor) {
-			this.putAllAt(tensor);
-		}
+        @Override
+        public void putAllMap(Map<Position, S> newEntries) {
+            this.entries.putAll(newEntries);
+        }
 
-	}
+        @Override
+        public void removeAt(Position position) {
+            entries.remove(position);
+        }
 
-	/**
-	 * When printing the tensor content output is automatically not larger then
-	 * N ant the beginning and N at the end of the Tensor entries.
-	 */
-	@Override
-	public String toString() {
-		StringBuffer buffer = new StringBuffer(TOSTRING_BUFFER_SIZE);
-		int totalSize = this.shape.positionSet().size();
-		int index = 1;
-		for (Position position : this.shape.positionSet()) {
-			if (index < POSITION_TO_DISPLAY || index > totalSize - POSITION_TO_DISPLAY) {
-				buffer.append(position + "=(" + get(position) + "), ");
-			} else if (index == POSITION_TO_DISPLAY) {
-				buffer.append(".. [" + (totalSize - 2 * POSITION_TO_DISPLAY) + " skipped entries] .. , ");
-			}
-			index++;
-		}
-		if (buffer.length() > 1) {
-			buffer.setLength(buffer.length() - 2);
-		}
-		return Coordinates.dimensionsWithoutClassPath(this) + ", Content:{" + buffer + "}";
-	}
+        @Override
+        public void put(java.util.Map.Entry<Position, S> entry) {
+            this.putAt(entry.getValue(), entry.getKey());
+        }
 
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((context == null) ? 0 : context.hashCode());
-		result = prime * result + ((entries == null) ? 0 : entries.hashCode());
-		result = prime * result + ((shape == null) ? 0 : shape.hashCode());
-		return result;
-	}
+        @Override
+        public void putAll(Tensor<S> tensor) {
+            this.putAllAt(tensor);
+        }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		@SuppressWarnings("rawtypes")
-		ImmutableTensor other = (ImmutableTensor) obj;
-		if (context == null) {
-			if (other.context != null)
-				return false;
-		} else if (!context.equals(other.context))
-			return false;
-		if (entries == null) {
-			if (other.entries != null)
-				return false;
-		} else if (!entries.equals(other.entries))
-			return false;
-		if (shape == null) {
-			if (other.shape != null)
-				return false;
-		} else if (!shape.equals(other.shape))
-			return false;
-		return true;
-	}
+    }
+
+    /**
+     * When printing the tensor content output is automatically not larger then N ant the beginning and N at the end of
+     * the Tensor entries.
+     */
+    @Override
+    public String toString() {
+        StringBuffer buffer = new StringBuffer(TOSTRING_BUFFER_SIZE);
+        int totalSize = this.shape.positionSet().size();
+        int index = 1;
+        for (Position position : this.shape.positionSet()) {
+            if (index < POSITION_TO_DISPLAY || index > totalSize - POSITION_TO_DISPLAY) {
+                buffer.append(position + "=(" + get(position) + "), ");
+            } else if (index == POSITION_TO_DISPLAY) {
+                buffer.append(".. [" + (totalSize - 2 * POSITION_TO_DISPLAY) + " skipped entries] .. , ");
+            }
+            index++;
+        }
+        if (buffer.length() > 1) {
+            buffer.setLength(buffer.length() - 2);
+        }
+        return Coordinates.dimensionsWithoutClassPath(this) + ", Content:{" + buffer + "}";
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((context == null) ? 0 : context.hashCode());
+        result = prime * result + ((entries == null) ? 0 : entries.hashCode());
+        result = prime * result + ((shape == null) ? 0 : shape.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        @SuppressWarnings("rawtypes")
+        ImmutableTensor other = (ImmutableTensor) obj;
+        if (context == null) {
+            if (other.context != null)
+                return false;
+        } else if (!context.equals(other.context))
+            return false;
+        if (entries == null) {
+            if (other.entries != null)
+                return false;
+        } else if (!entries.equals(other.entries))
+            return false;
+        if (shape == null) {
+            if (other.shape != null)
+                return false;
+        } else if (!shape.equals(other.shape))
+            return false;
+        return true;
+    }
 
 }

--- a/src/java/org/tensorics/core/tensor/Tensor.java
+++ b/src/java/org/tensorics/core/tensor/Tensor.java
@@ -55,10 +55,11 @@ public interface Tensor<E> {
     Iterable<Entry<E>> entrySet();
 
     /**
-     * @return all the entries as a map of Position to value.
+     * @return all the entries as a map of Position to value. There is no guarantee about the thread safety or
+     *         mutability of the returned {@link Map}.
      */
     Map<Position, E> asMap();
-    
+
     /**
      * @return the shape of the tensor. The RAW coordinates structure, no tensor values are returend here.
      */

--- a/src/java/org/tensorics/core/tensor/stream/AbstractTensoricCollector.java
+++ b/src/java/org/tensorics/core/tensor/stream/AbstractTensoricCollector.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2016 European Organisation for Nuclear Research (CERN), All Rights Reserved.
+ */
+
+package org.tensorics.core.tensor.stream;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+import org.tensorics.core.tensor.Position;
+
+public abstract class AbstractTensoricCollector<V, T, O> implements Collector<V, Map<Position, T>, O> {
+
+    private final Function<V, Position> positionMapper;
+    private final Function<V, T> valueMapper;
+
+    public AbstractTensoricCollector(Function<V, Position> positionMapper, Function<V, T> valueMapper) {
+        this.positionMapper = positionMapper;
+        this.valueMapper = valueMapper;
+    }
+
+    @Override
+    public Supplier<Map<Position, T>> supplier() {
+        return HashMap::new;
+    }
+
+    @Override
+    public BiConsumer<Map<Position, T>, V> accumulator() {
+        return (map, entry) -> {
+            Position position = positionMapper.apply(entry);
+            if (map.put(position, valueMapper.apply(entry)) != null) {
+                throw new IllegalStateException("duplicate entry for position " + position);
+            }
+        };
+    }
+
+    @Override
+    public BinaryOperator<Map<Position, T>> combiner() {
+        return (map1, map2) -> {
+            Map<Position, T> mergedMap = new HashMap<>(map1);
+            mergedMap.putAll(map2);
+            return mergedMap;
+        };
+    }
+
+    @Override
+    public Set<java.util.stream.Collector.Characteristics> characteristics() {
+        return Collections.singleton(Collector.Characteristics.UNORDERED);
+    }
+
+}

--- a/src/java/org/tensorics/core/tensor/stream/AbstractTensoricCollector.java
+++ b/src/java/org/tensorics/core/tensor/stream/AbstractTensoricCollector.java
@@ -1,6 +1,24 @@
-/**
- * Copyright (c) 2016 European Organisation for Nuclear Research (CERN), All Rights Reserved.
- */
+// @formatter:off
+ /*******************************************************************************
+ *
+ * This file is part of tensorics.
+ * 
+ * Copyright (c) 2008-2011, CERN. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ ******************************************************************************/
+// @formatter:on
 
 package org.tensorics.core.tensor.stream;
 
@@ -15,7 +33,18 @@ import java.util.function.Supplier;
 import java.util.stream.Collector;
 
 import org.tensorics.core.tensor.Position;
+import org.tensorics.core.tensorbacked.Tensorbacked;
+import org.tensorics.core.tensor.Tensor;
 
+/**
+ * Abstract base class for a stream {@link Collector} which is backed by a map of {@link Position} to an arbitrary
+ * value, from which a {@link Tensor} or {@link Tensorbacked} can be built in the finalization step.
+ * 
+ * @author mihostet 
+ * @param <V> stream elements
+ * @param <T> elements of the tensor to be produced
+ * @param <O> output (e.g. Tensor<T> or Tensorbacked<T>)
+ */
 public abstract class AbstractTensoricCollector<V, T, O> implements Collector<V, Map<Position, T>, O> {
 
     private final Function<V, Position> positionMapper;

--- a/src/java/org/tensorics/core/tensor/stream/TensorCollector.java
+++ b/src/java/org/tensorics/core/tensor/stream/TensorCollector.java
@@ -7,7 +7,6 @@ package org.tensorics.core.tensor.stream;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.BinaryOperator;
@@ -19,7 +18,16 @@ import org.tensorics.core.lang.Tensorics;
 import org.tensorics.core.tensor.Position;
 import org.tensorics.core.tensor.Tensor;
 
-public class TensorCollector<T> implements Collector<Map.Entry<Position, T>, Map<Position, T>, Tensor<T>> {
+public class TensorCollector<V, T> implements Collector<V, Map<Position, T>, Tensor<T>> {
+
+    private final Function<V, Position> positionMapper;
+    private final Function<V, T> valueMapper;
+    
+    
+    public TensorCollector(Function<V, Position> positionMapper, Function<V, T> valueMapper) {
+        this.positionMapper = positionMapper;
+        this.valueMapper = valueMapper;
+    }
 
     @Override
     public Supplier<Map<Position, T>> supplier() {
@@ -27,8 +35,8 @@ public class TensorCollector<T> implements Collector<Map.Entry<Position, T>, Map
     }
 
     @Override
-    public BiConsumer<Map<Position, T>, Entry<Position, T>> accumulator() {
-        return (map, entry) -> map.put(entry.getKey(), entry.getValue());
+    public BiConsumer<Map<Position, T>, V> accumulator() {
+        return (map, entry) -> map.put(positionMapper.apply(entry), valueMapper.apply(entry));
     }
 
     @Override

--- a/src/java/org/tensorics/core/tensor/stream/TensorCollector.java
+++ b/src/java/org/tensorics/core/tensor/stream/TensorCollector.java
@@ -1,6 +1,24 @@
-/**
- * Copyright (c) 2016 European Organisation for Nuclear Research (CERN), All Rights Reserved.
- */
+// @formatter:off
+ /*******************************************************************************
+ *
+ * This file is part of tensorics.
+ * 
+ * Copyright (c) 2008-2011, CERN. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ ******************************************************************************/
+// @formatter:on
 
 package org.tensorics.core.tensor.stream;
 
@@ -11,6 +29,13 @@ import org.tensorics.core.lang.Tensorics;
 import org.tensorics.core.tensor.Position;
 import org.tensorics.core.tensor.Tensor;
 
+/**
+ * An {@link AbstractTensoricCollector} implementation to produce a generic tensor
+ * 
+ * @author mihostet 
+ * @param <V> stream elements
+ * @param <T> elements of the tensor (will build a Tensor<T>)
+ */
 public class TensorCollector<V, T> extends AbstractTensoricCollector<V, T, Tensor<T>> {
 
     public TensorCollector(Function<V, Position> positionMapper, Function<V, T> valueMapper) {

--- a/src/java/org/tensorics/core/tensor/stream/TensorCollector.java
+++ b/src/java/org/tensorics/core/tensor/stream/TensorCollector.java
@@ -4,58 +4,22 @@
 
 package org.tensorics.core.tensor.stream;
 
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
-import java.util.function.BiConsumer;
-import java.util.function.BinaryOperator;
 import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.stream.Collector;
 
 import org.tensorics.core.lang.Tensorics;
 import org.tensorics.core.tensor.Position;
 import org.tensorics.core.tensor.Tensor;
 
-public class TensorCollector<V, T> implements Collector<V, Map<Position, T>, Tensor<T>> {
+public class TensorCollector<V, T> extends AbstractTensoricCollector<V, T, Tensor<T>> {
 
-    private final Function<V, Position> positionMapper;
-    private final Function<V, T> valueMapper;
-    
-    
     public TensorCollector(Function<V, Position> positionMapper, Function<V, T> valueMapper) {
-        this.positionMapper = positionMapper;
-        this.valueMapper = valueMapper;
-    }
-
-    @Override
-    public Supplier<Map<Position, T>> supplier() {
-        return HashMap::new;
-    }
-
-    @Override
-    public BiConsumer<Map<Position, T>, V> accumulator() {
-        return (map, entry) -> map.put(positionMapper.apply(entry), valueMapper.apply(entry));
-    }
-
-    @Override
-    public BinaryOperator<Map<Position, T>> combiner() {
-        return (map1, map2) -> {
-            Map<Position, T> mergedMap = new HashMap<>(map1);
-            mergedMap.putAll(map2);
-            return mergedMap;
-        };
+        super(positionMapper, valueMapper);
     }
 
     @Override
     public Function<Map<Position, T>, Tensor<T>> finisher() {
         return Tensorics::fromMap;
-    }
-
-    @Override
-    public Set<java.util.stream.Collector.Characteristics> characteristics() {
-        return Collections.singleton(Collector.Characteristics.UNORDERED);
     }
 
 }

--- a/src/java/org/tensorics/core/tensor/stream/TensorCollector.java
+++ b/src/java/org/tensorics/core/tensor/stream/TensorCollector.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2016 European Organisation for Nuclear Research (CERN), All Rights Reserved.
+ */
+
+package org.tensorics.core.tensor.stream;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+import org.tensorics.core.lang.Tensorics;
+import org.tensorics.core.tensor.Position;
+import org.tensorics.core.tensor.Tensor;
+
+public class TensorCollector<T> implements Collector<Map.Entry<Position, T>, Map<Position, T>, Tensor<T>> {
+
+    @Override
+    public Supplier<Map<Position, T>> supplier() {
+        return HashMap::new;
+    }
+
+    @Override
+    public BiConsumer<Map<Position, T>, Entry<Position, T>> accumulator() {
+        return (map, entry) -> map.put(entry.getKey(), entry.getValue());
+    }
+
+    @Override
+    public BinaryOperator<Map<Position, T>> combiner() {
+        return (map1, map2) -> {
+            Map<Position, T> mergedMap = new HashMap<>(map1);
+            mergedMap.putAll(map2);
+            return mergedMap;
+        };
+    }
+
+    @Override
+    public Function<Map<Position, T>, Tensor<T>> finisher() {
+        return Tensorics::fromMap;
+    }
+
+    @Override
+    public Set<java.util.stream.Collector.Characteristics> characteristics() {
+        return Collections.singleton(Collector.Characteristics.UNORDERED);
+    }
+
+}

--- a/src/java/org/tensorics/core/tensor/stream/TensorStreamFilters.java
+++ b/src/java/org/tensorics/core/tensor/stream/TensorStreamFilters.java
@@ -1,6 +1,24 @@
-/**
- * Copyright (c) 2016 European Organisation for Nuclear Research (CERN), All Rights Reserved.
- */
+// @formatter:off
+ /*******************************************************************************
+ *
+ * This file is part of tensorics.
+ * 
+ * Copyright (c) 2008-2011, CERN. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ ******************************************************************************/
+// @formatter:on
 
 package org.tensorics.core.tensor.stream;
 
@@ -9,6 +27,12 @@ import java.util.function.Predicate;
 
 import org.tensorics.core.tensor.Position;
 
+/**
+ * Utility class to produce {@link Predicate}s to use in a stream of Entry<Position, T>, in particular for the
+ * filter() method, in a convenient way.
+ * 
+ * @author mihostet
+ */
 public final class TensorStreamFilters {
 
     private TensorStreamFilters() {

--- a/src/java/org/tensorics/core/tensor/stream/TensorStreamFilters.java
+++ b/src/java/org/tensorics/core/tensor/stream/TensorStreamFilters.java
@@ -15,6 +15,11 @@ public final class TensorStreamFilters {
         /* static only */
     }
 
+    public static <T, C> Predicate<Map.Entry<Position, T>> byCoordinateOfType(Class<C> dimension,
+            Predicate<C> positionPredicate) {
+        return entry -> positionPredicate.test(entry.getKey().coordinateFor(dimension));
+    }
+
     public static <T> Predicate<Map.Entry<Position, T>> byPosition(Predicate<Position> positionPredicate) {
         return entry -> positionPredicate.test(entry.getKey());
     }

--- a/src/java/org/tensorics/core/tensor/stream/TensorStreamFilters.java
+++ b/src/java/org/tensorics/core/tensor/stream/TensorStreamFilters.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2016 European Organisation for Nuclear Research (CERN), All Rights Reserved.
+ */
+
+package org.tensorics.core.tensor.stream;
+
+import java.util.Map;
+import java.util.function.Predicate;
+
+import org.tensorics.core.tensor.Position;
+
+public final class TensorStreamFilters {
+
+    private TensorStreamFilters() {
+        /* static only */
+    }
+
+    public static <T> Predicate<Map.Entry<Position, T>> byPosition(Predicate<Position> positionPredicate) {
+        return entry -> positionPredicate.test(entry.getKey());
+    }
+
+    public static <T> Predicate<Map.Entry<Position, T>> byValue(Predicate<T> valuePredicate) {
+        return entry -> valuePredicate.test(entry.getValue());
+    }
+}

--- a/src/java/org/tensorics/core/tensor/stream/TensorStreamMappers.java
+++ b/src/java/org/tensorics/core/tensor/stream/TensorStreamMappers.java
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2016 European Organisation for Nuclear Research (CERN), All Rights Reserved.
+ */
+
+package org.tensorics.core.tensor.stream;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.tensorics.core.tensor.Position;
+
+public final class TensorStreamMappers {
+    private TensorStreamMappers() {
+        /* static only */
+    }
+    
+    public static <T> Function<Map.Entry<Position, T>, Map.Entry<Position, T>> positions(
+            Function<Position, Position> positionMapper) {
+        return entry -> new ImmutableTensorEntry<>(positionMapper.apply(entry.getKey()), entry.getValue());
+    }
+
+    public static <I, O> Function<Map.Entry<Position, I>, Map.Entry<Position, O>> values(Function<I, O> valueMapper) {
+        return entry -> new ImmutableTensorEntry<>(entry.getKey(), valueMapper.apply(entry.getValue()));
+    }
+
+    public static <T> Function<Map.Entry<Position, T>, Map.Entry<Position, T>> positions(
+            BiFunction<Position, T, Position> positionMapper) {
+        return entry -> new ImmutableTensorEntry<>(positionMapper.apply(entry.getKey(), entry.getValue()),
+                entry.getValue());
+    }
+
+    public static <I, O> Function<Map.Entry<Position, I>, Map.Entry<Position, O>> values(
+            BiFunction<Position, I, O> valueMapper) {
+        return entry -> new ImmutableTensorEntry<>(entry.getKey(), valueMapper.apply(entry.getKey(), entry.getValue()));
+    }
+
+    
+    private static class ImmutableTensorEntry<T> implements Map.Entry<Position, T> {
+
+        private final Position position;
+        private final T value;
+
+        public ImmutableTensorEntry(Position position, T value) {
+            this.position = position;
+            this.value = value;
+        }
+
+        @Override
+        public Position getKey() {
+            return position;
+        }
+
+        @Override
+        public T getValue() {
+            return value;
+        }
+
+        @Override
+        public T setValue(T value) {
+            throw new UnsupportedOperationException("this entry is immutable");
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((position == null) ? 0 : position.hashCode());
+            result = prime * result + ((value == null) ? 0 : value.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            ImmutableTensorEntry<?> other = (ImmutableTensorEntry<?>) obj;
+            if (position == null) {
+                if (other.position != null)
+                    return false;
+            } else if (!position.equals(other.position))
+                return false;
+            if (value == null) {
+                if (other.value != null)
+                    return false;
+            } else if (!value.equals(other.value))
+                return false;
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "ImmutableTensorEntry [position=" + position + ", value=" + value + "]";
+        }
+
+    }
+}

--- a/src/java/org/tensorics/core/tensor/stream/TensorStreamMappers.java
+++ b/src/java/org/tensorics/core/tensor/stream/TensorStreamMappers.java
@@ -1,6 +1,24 @@
-/**
- * Copyright (c) 2016 European Organisation for Nuclear Research (CERN), All Rights Reserved.
- */
+// @formatter:off
+ /*******************************************************************************
+ *
+ * This file is part of tensorics.
+ * 
+ * Copyright (c) 2008-2011, CERN. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ ******************************************************************************/
+// @formatter:on
 
 package org.tensorics.core.tensor.stream;
 
@@ -12,6 +30,12 @@ import java.util.function.Function;
 
 import org.tensorics.core.tensor.Position;
 
+/**
+ * Utility class to create {@link Function}s to be used to map() a stream of Entry<Position, T>. Using these convenience
+ * functions avoids the user having to explicitly extract the Entry, modify it and re-build it in the end.
+ * 
+ * @author mihostet
+ */
 public final class TensorStreamMappers {
     private TensorStreamMappers() {
         /* static only */
@@ -28,8 +52,8 @@ public final class TensorStreamMappers {
             }
             CO newCoordinate = coordinateMapper.apply(oldCoordinate);
             if (position.coordinateFor(newCoordinate.getClass()) != null) {
-                throw new IllegalArgumentException("Can't map to coordinate of dimension " + newCoordinate.getClass()
-                        + ", already present in Position " + position);
+                throw new IllegalArgumentException("Can't map to coordinate of dimension "
+                        + newCoordinate.getClass().getCanonicalName() + ", already present in Position " + position);
             }
             Set<Object> coordinates = new HashSet<>(position.getCoordinates().values());
             coordinates.remove(oldCoordinate);

--- a/src/java/org/tensorics/core/tensor/stream/TensorStreams.java
+++ b/src/java/org/tensorics/core/tensor/stream/TensorStreams.java
@@ -10,6 +10,7 @@ import java.util.stream.Stream;
 
 import org.tensorics.core.tensor.Position;
 import org.tensorics.core.tensor.Tensor;
+import org.tensorics.core.tensorbacked.Tensorbacked;
 
 public final class TensorStreams {
     private TensorStreams() {
@@ -34,6 +35,16 @@ public final class TensorStreams {
     public static <V, T> TensorCollector<V, T> toTensor(Function<V, Position> positionMapper,
             Function<V, T> valueMapper) {
         return new TensorCollector<>(positionMapper, valueMapper);
+    }
+
+    public static <T, TB extends Tensorbacked<T>> TensorbackedCollector<Map.Entry<Position, T>, T, TB> toTensorbacked(
+            Class<TB> tensorBackedClass) {
+        return new TensorbackedCollector<>(tensorBackedClass, Map.Entry::getKey, Map.Entry::getValue);
+    }
+
+    public static <V, T, TB extends Tensorbacked<T>> TensorbackedCollector<V, T, TB> toTensorbacked(
+            Class<TB> tensorBackedClass, Function<V, Position> positionMapper, Function<V, T> valueMapper) {
+        return new TensorbackedCollector<>(tensorBackedClass, positionMapper, valueMapper);
     }
 
 }

--- a/src/java/org/tensorics/core/tensor/stream/TensorStreams.java
+++ b/src/java/org/tensorics/core/tensor/stream/TensorStreams.java
@@ -1,6 +1,24 @@
-/**
- * Copyright (c) 2016 European Organisation for Nuclear Research (CERN), All Rights Reserved.
- */
+// @formatter:off
+ /*******************************************************************************
+ *
+ * This file is part of tensorics.
+ * 
+ * Copyright (c) 2008-2011, CERN. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ ******************************************************************************/
+// @formatter:on
 
 package org.tensorics.core.tensor.stream;
 
@@ -12,9 +30,14 @@ import org.tensorics.core.tensor.Position;
 import org.tensorics.core.tensor.Tensor;
 import org.tensorics.core.tensorbacked.Tensorbacked;
 
+/**
+ * Utility class for producing streams of Entry<Position, T> out of Tensors and collecting them back into Tensors.
+ * 
+ * @author mihostet
+ */
 public final class TensorStreams {
     private TensorStreams() {
-
+        /* static only */
     }
 
     /**
@@ -28,20 +51,50 @@ public final class TensorStreams {
 
     }
 
+    /**
+     * Build a collector to collect a stream of Entry<Position,T> to a generic Tensor<T>
+     * 
+     * @return
+     */
     public static <T> TensorCollector<Map.Entry<Position, T>, T> toTensor() {
         return new TensorCollector<>(Map.Entry::getKey, Map.Entry::getValue);
     }
 
+    /**
+     * Build a collector to collect an arbitrary stream to a generic Tensor<T>. Functions mapping the values to
+     * {@link Position} and T must be provided.
+     * 
+     * @param positionMapper function mapping stream values to Position
+     * @param valueMapper function mapping stream values to tensor values
+     * @return
+     */
     public static <V, T> TensorCollector<V, T> toTensor(Function<V, Position> positionMapper,
             Function<V, T> valueMapper) {
         return new TensorCollector<>(positionMapper, valueMapper);
     }
 
+    /**
+     * Build a collector to collect a stream of Entry<Position,T> to a Tensorbacked<T> class. The {@link Position}s in
+     * the stream must be consistent with the dimensions of the Tensorbacked.
+     * 
+     * @param tensorBackedClass the tensorbacked to produce
+     * @return
+     */
     public static <T, TB extends Tensorbacked<T>> TensorbackedCollector<Map.Entry<Position, T>, T, TB> toTensorbacked(
             Class<TB> tensorBackedClass) {
         return new TensorbackedCollector<>(tensorBackedClass, Map.Entry::getKey, Map.Entry::getValue);
     }
 
+    /**
+     * Build a collector to collect an arbitrary stream to a Tensorbackedclass. Functions mapping the values to
+     * {@link Position} and T must be provided. The {@link Position}s generated must be consistent with the dimensions
+     * of the Tensorbacked.
+     * 
+     * @param tensorBackedClass the tensorbacked to produce
+     * @param positionMapper function mapping stream values to Position
+     * @param valueMapper function mapping stream values to tensor values
+     * @return
+     */
     public static <V, T, TB extends Tensorbacked<T>> TensorbackedCollector<V, T, TB> toTensorbacked(
             Class<TB> tensorBackedClass, Function<V, Position> positionMapper, Function<V, T> valueMapper) {
         return new TensorbackedCollector<>(tensorBackedClass, positionMapper, valueMapper);

--- a/src/java/org/tensorics/core/tensor/stream/TensorStreams.java
+++ b/src/java/org/tensorics/core/tensor/stream/TensorStreams.java
@@ -5,6 +5,7 @@
 package org.tensorics.core.tensor.stream;
 
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import org.tensorics.core.tensor.Position;
@@ -26,8 +27,13 @@ public final class TensorStreams {
 
     }
 
-    public static <T> TensorCollector<T> toTensor() {
-        return new TensorCollector<>();
+    public static <T> TensorCollector<Map.Entry<Position, T>, T> toTensor() {
+        return new TensorCollector<>(Map.Entry::getKey, Map.Entry::getValue);
+    }
+
+    public static <V, T> TensorCollector<V, T> toTensor(Function<V, Position> positionMapper,
+            Function<V, T> valueMapper) {
+        return new TensorCollector<>(positionMapper, valueMapper);
     }
 
 }

--- a/src/java/org/tensorics/core/tensor/stream/TensorStreams.java
+++ b/src/java/org/tensorics/core/tensor/stream/TensorStreams.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2016 European Organisation for Nuclear Research (CERN), All Rights Reserved.
+ */
+
+package org.tensorics.core.tensor.stream;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.tensorics.core.tensor.Position;
+import org.tensorics.core.tensor.Tensor;
+
+public final class TensorStreams {
+    private TensorStreams() {
+
+    }
+
+    /**
+     * Return a stream of all entries of the tensor
+     * 
+     * @param tensor
+     * @return
+     */
+    public static <S> Stream<Map.Entry<Position, S>> tensorEntryStream(Tensor<S> tensor) {
+        return tensor.asMap().entrySet().stream();
+
+    }
+
+    public static <T> TensorCollector<T> toTensor() {
+        return new TensorCollector<>();
+    }
+
+}

--- a/src/java/org/tensorics/core/tensor/stream/TensorbackedCollector.java
+++ b/src/java/org/tensorics/core/tensor/stream/TensorbackedCollector.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016 European Organisation for Nuclear Research (CERN), All Rights Reserved.
+ */
+
+package org.tensorics.core.tensor.stream;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import org.tensorics.core.lang.Tensorics;
+import org.tensorics.core.tensor.Position;
+import org.tensorics.core.tensorbacked.Tensorbacked;
+import org.tensorics.core.tensorbacked.TensorbackedInternals;
+
+public class TensorbackedCollector<V, T, TB extends Tensorbacked<T>> extends AbstractTensoricCollector<V, T, TB> {
+
+    private final Class<TB> tensorBackedClass;
+
+    public TensorbackedCollector(Class<TB> tensorBackedClass, Function<V, Position> positionMapper,
+            Function<V, T> valueMapper) {
+        super(positionMapper, valueMapper);
+        this.tensorBackedClass = tensorBackedClass;
+    }
+
+    @Override
+    public Function<Map<Position, T>, TB> finisher() {
+        return map -> TensorbackedInternals.createBackedByTensor(tensorBackedClass, Tensorics.fromMap(map));
+
+    }
+
+}

--- a/src/java/org/tensorics/core/tensor/stream/TensorbackedCollector.java
+++ b/src/java/org/tensorics/core/tensor/stream/TensorbackedCollector.java
@@ -1,6 +1,24 @@
-/**
- * Copyright (c) 2016 European Organisation for Nuclear Research (CERN), All Rights Reserved.
- */
+// @formatter:off
+ /*******************************************************************************
+ *
+ * This file is part of tensorics.
+ * 
+ * Copyright (c) 2008-2011, CERN. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ ******************************************************************************/
+// @formatter:on
 
 package org.tensorics.core.tensor.stream;
 
@@ -12,6 +30,14 @@ import org.tensorics.core.tensor.Position;
 import org.tensorics.core.tensorbacked.Tensorbacked;
 import org.tensorics.core.tensorbacked.TensorbackedInternals;
 
+/**
+ * An {@link AbstractTensoricCollector} implementation to collect to an arbitrary {@link Tensorbacked} class.
+ * 
+ * @author mihostet 
+ * @param <V> steam elements
+ * @param <T> elements of the tensor in the tensorbacked
+ * @param <TB> tensorbacked class to produce, must extend Tensorbacked<T>
+ */
 public class TensorbackedCollector<V, T, TB extends Tensorbacked<T>> extends AbstractTensoricCollector<V, T, TB> {
 
     private final Class<TB> tensorBackedClass;

--- a/src/test/org/tensorics/core/tensor/ImmutableTensorTest.java
+++ b/src/test/org/tensorics/core/tensor/ImmutableTensorTest.java
@@ -25,6 +25,7 @@ package org.tensorics.core.tensor;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Collections;
+import java.util.Map;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,6 +33,7 @@ import org.junit.rules.ExpectedException;
 import org.tensorics.core.lang.Tensorics;
 import org.tensorics.core.tensor.ImmutableTensor.Builder;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 public class ImmutableTensorTest {
@@ -93,6 +95,26 @@ public class ImmutableTensorTest {
         thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("unique");
         Tensorics.builder(Integer.class, Integer.class);
+    }
+    
+    @Test
+    public void fromMapWithOneEntry() {
+        Map<Position, Integer> map = ImmutableMap.of(Position.of(42), 0);
+        assertEquals(Tensorics.fromMap(map).asMap(), map);
+    }
+
+    @Test
+    public void fromEmptyMap() {
+        Map<Position, Integer> map = ImmutableMap.of();
+        assertEquals(Tensorics.fromMap(map).asMap(), map);
+    }
+
+    @Test
+    public void fromMapThrowsOnInconsistentDimensions() {
+        Map<Position, Integer> map = ImmutableMap.of(Position.of(42), 0, Position.of("fail"), 1);
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("same dimensions");
+        Tensorics.fromMap(map);
     }
 
 }

--- a/src/test/org/tensorics/core/tensor/stream/TensorStreamsTest.java
+++ b/src/test/org/tensorics/core/tensor/stream/TensorStreamsTest.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016 European Organisation for Nuclear Research (CERN), All Rights Reserved.
+ */
+
+package org.tensorics.core.tensor.stream;
+
+import static org.junit.Assert.*;
+import static org.tensorics.core.tensor.stream.TensorStreamFilters.byValue;
+import static org.tensorics.core.tensor.stream.TensorStreams.toTensor;
+import static org.tensorics.core.tensor.stream.TensorStreamMappers.values;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.tensorics.core.lang.Tensorics;
+import org.tensorics.core.tensor.ImmutableTensor;
+import org.tensorics.core.tensor.Position;
+import org.tensorics.core.tensor.Tensor;
+import org.tensorics.core.tensor.ImmutableTensor.Builder;
+
+import com.google.common.collect.ImmutableSet;
+
+public class TensorStreamsTest {
+
+    Tensor<Double> tensor;
+
+    @Before
+    public void prepareTensor() {
+        Builder<Double> tensorBuilder = ImmutableTensor.builder(ImmutableSet.of(Double.class, Integer.class));
+        tensorBuilder.putAt(0.0, Position.of(0.0, 0));
+        tensorBuilder.putAt(42.42, Position.of(23.0, 42));
+        tensor = tensorBuilder.build();
+    }
+
+    @Test
+    public void test() {
+        Tensor<Double> mapped = Tensorics.stream(tensor).map(values(e -> e + 1)).filter(byValue(e -> e > 5))
+                .collect(toTensor());
+
+        assertEquals(1, mapped.shape().size());
+        assertEquals(43.42, mapped.get(23.0, 42), 1e-6);
+    }
+
+}

--- a/src/test/org/tensorics/core/tensor/stream/TensorStreamsTest.java
+++ b/src/test/org/tensorics/core/tensor/stream/TensorStreamsTest.java
@@ -7,27 +7,53 @@ package org.tensorics.core.tensor.stream;
 import static org.junit.Assert.*;
 import static org.tensorics.core.tensor.stream.TensorStreamFilters.byValue;
 import static org.tensorics.core.tensor.stream.TensorStreams.toTensor;
+import static org.tensorics.core.tensor.stream.TensorStreams.toTensorbacked;
+import static org.tensorics.core.tensor.stream.TensorStreamMappers.coordinatesOfType;
 import static org.tensorics.core.tensor.stream.TensorStreamMappers.values;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.tensorics.core.lang.Tensorics;
 import org.tensorics.core.tensor.ImmutableTensor;
 import org.tensorics.core.tensor.Position;
 import org.tensorics.core.tensor.Tensor;
+import org.tensorics.core.tensorbacked.AbstractTensorbacked;
+import org.tensorics.core.tensorbacked.annotation.Dimensions;
 import org.tensorics.core.tensor.ImmutableTensor.Builder;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 public class TensorStreamsTest {
 
-    Tensor<Double> tensor;
+    private enum TestCoordinate {
+        FIRST_VALUE,
+        SECOND_VALUE,
+        THIRD_VALUE
+    }
+
+    @Dimensions({ TestCoordinate.class, Double.class })
+    private static class SomeDomainObject extends AbstractTensorbacked<Double> {
+        private static final long serialVersionUID = 1L;
+
+        public SomeDomainObject(Tensor<Double> tensor) {
+            super(tensor);
+        }
+    }
+
+    private Tensor<Double> tensor;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Before
     public void prepareTensor() {
         Builder<Double> tensorBuilder = ImmutableTensor.builder(ImmutableSet.of(Double.class, Integer.class));
         tensorBuilder.putAt(0.0, Position.of(0.0, 0));
-        tensorBuilder.putAt(42.42, Position.of(23.0, 42));
+        tensorBuilder.putAt(42.42, Position.of(23.0, 1));
+        tensorBuilder.putAt(2.0, Position.of(23.0, 2));
         tensor = tensorBuilder.build();
     }
 
@@ -37,7 +63,35 @@ public class TensorStreamsTest {
                 .collect(toTensor());
 
         assertEquals(1, mapped.shape().size());
-        assertEquals(43.42, mapped.get(23.0, 42), 1e-6);
+        assertEquals(43.42, mapped.get(23.0, 1), 1e-6);
+    }
+
+    @Test
+    public void convertTensorToDomainObjectByStreams() {
+        SomeDomainObject domainObject = Tensorics.stream(tensor)
+                .map(coordinatesOfType(Integer.class, i -> TestCoordinate.values()[i]))
+                .collect(toTensorbacked(SomeDomainObject.class));
+
+        assertEquals(0.0, domainObject.tensor().get(0.0, TestCoordinate.FIRST_VALUE), 1e-6);
+        assertEquals(42.42, domainObject.tensor().get(23.0, TestCoordinate.SECOND_VALUE), 1e-6);
+        assertEquals(2.0, domainObject.tensor().get(23.0, TestCoordinate.THIRD_VALUE), 1e-6);
+    }
+
+    @Test
+    public void duplicatePositionThrows() {
+        thrown.expect(IllegalStateException.class);
+        thrown.expectMessage("duplicate entry");
+
+        ImmutableList.of(1, 2, 3).stream().collect(toTensor(any -> Position.empty(), v -> v));
+    }
+
+    @Test
+    public void inconsistentPositionThrows() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("same dimensions");
+
+        Position positions[] = new Position[] { Position.of(1), Position.of(42.0), Position.of("fail") };        
+        ImmutableList.of(0, 1, 2).stream().collect(toTensor(i -> positions[i], v -> v));
     }
 
 }

--- a/src/test/org/tensorics/core/tensor/stream/TensorStreamsTest.java
+++ b/src/test/org/tensorics/core/tensor/stream/TensorStreamsTest.java
@@ -1,6 +1,24 @@
-/**
- * Copyright (c) 2016 European Organisation for Nuclear Research (CERN), All Rights Reserved.
- */
+// @formatter:off
+ /*******************************************************************************
+ *
+ * This file is part of tensorics.
+ * 
+ * Copyright (c) 2008-2011, CERN. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ ******************************************************************************/
+// @formatter:on
 
 package org.tensorics.core.tensor.stream;
 


### PR DESCRIPTION
@kaifox @andreacalia @agorzawski
Hi, me and Andrea worked a bit on enabling java8 streams for tensors, i.e. streaming a tensor and collecting a stream to a tensor. So far we use streams of Map.Entry ... not sure if this is the best approach or if we should re-enable the Tensor.Entry at some point.

This are all supposed to be purely structural operations, no tensor math involved.

This is a first implementation ... more functionality can be added once needed.

Cheers,
Michi and Andrea
