### PR TITLE
fix interface handling in shapes & calculations

### DIFF
--- a/src/java/org/tensorics/core/tensor/Shape.java
+++ b/src/java/org/tensorics/core/tensor/Shape.java
@@ -176,8 +176,10 @@ public final class Shape implements Serializable {
      * @param positions the positions which shall be used for the new shape
      * @return a new shape, containing the given positions
      * @throws IllegalArgumentException if the dimensions of the individual positions are not consistent.
+     * @deprecated Using this method to construct a shape guesses the dimensionality from the passed positions.
      */
     @SuppressWarnings("PMD.ShortMethodName")
+    @Deprecated
     public static Shape of(Iterable<Position> positions) {
         return builder().addAll(positions).build();
     }
@@ -189,11 +191,42 @@ public final class Shape implements Serializable {
      * @return a new shape containing the given positions
      * @see #of(Iterable)
      * @throws IllegalArgumentException if the dimensions of the positions are inconsistent
+     * @deprecated Using this method to construct a shape guesses the dimensionality from the passed positions.
      */
     @SafeVarargs
     @SuppressWarnings("PMD.ShortMethodName")
+    @Deprecated
     public static Shape of(Position... positions) {
         return of(Arrays.asList(positions));
+    }
+
+    /**
+     * Creates a shape from the given set of positions and dimensions (types of coordinates). If the given positions do
+     * not correspond to the same dimensions, then an {@link IllegalArgumentException} will be thrown.
+     * 
+     * @param dimensions the dimensions for the new shape
+     * @param positions the positions which shall be used for the new shape
+     * @return a new shape, containing the given positions
+     * @throws IllegalArgumentException if the dimensions of the individual positions are not consistent.
+     */
+    @SuppressWarnings("PMD.ShortMethodName")
+    public static Shape of(Set<Class<?>> dimensions, Iterable<Position> positions) {
+        return builder(dimensions).addAll(positions).build();
+    }
+
+    /**
+     * This is a convenience method to be used instead of {@link #of(Set,Iterable)}.
+     * 
+     * @param dimensions the dimensions for the new shape
+     * @param positions the positions for the new shape
+     * @return a new shape containing the given positions
+     * @see #of(Iterable)
+     * @throws IllegalArgumentException if the dimensions of the positions are inconsistent
+     */
+    @SafeVarargs
+    @SuppressWarnings("PMD.ShortMethodName")
+    public static Shape of(Set<Class<?>> dimensions, Position... positions) {
+        return of(dimensions, Arrays.asList(positions));
     }
 
     /**
@@ -317,7 +350,7 @@ public final class Shape implements Serializable {
 
     @Override
     public String toString() {
-        return "Shape [dimensions=" + dimensions+ ", #positions=" + positions.size() + "]";
+        return "Shape [dimensions=" + dimensions + ", #positions=" + positions.size() + "]";
     }
 
 }

--- a/src/java/org/tensorics/core/tensor/options/BroadcastMissingDimensionsStrategy.java
+++ b/src/java/org/tensorics/core/tensor/options/BroadcastMissingDimensionsStrategy.java
@@ -30,6 +30,7 @@ import java.util.Set;
 
 import org.tensorics.core.tensor.BroadcastedTensorView;
 import org.tensorics.core.tensor.Shape;
+import org.tensorics.core.tensor.Shapes;
 import org.tensorics.core.tensor.Tensor;
 import org.tensorics.core.tensor.TensorPair;
 
@@ -47,8 +48,8 @@ import com.google.common.collect.Sets;
  * <li>broadcasted left: {[x1,y1]=1.0, [x1,y2]=1.0, [x2,y1]=2.0, [x2,y2]=2.0},
  * <li>broadcasted left: {[x1,y1]=0.1, [x1,y2]=0.2, [x2,y1]=0.1, [x2,y2]=0.2}.
  * </ul>
- * This strategy is rather close to the behaviour of <a
- * href="http://docs.scipy.org/doc/numpy/user/basics.broadcasting.html">numpy</a>, but has one very important
+ * This strategy is rather close to the behaviour of
+ * <a href="http://docs.scipy.org/doc/numpy/user/basics.broadcasting.html">numpy</a>, but has one very important
  * difference: It does NOT broadcast dimensions with one entry. So, if e.g. in the following example, the second tensor
  * would have had a different shape, like {[x1, y1]=1.0, [x2, y1]=2.0}, then it would have remained the same after
  * broadcasting and the shapes of the two resulting tensors would be different. This still can be useful in
@@ -69,15 +70,15 @@ public class BroadcastMissingDimensionsStrategy implements BroadcastingStrategy 
         checkNotNull(left, "left tensor must not be null");
         checkNotNull(right, "right tensor must not be null");
 
-        Set<Class<?>> dimensionalIntersection = dimensionalIntersection(left.shape(), right.shape());
+        Set<Class<?>> dimensionalIntersection = Shapes.parentDimensionalIntersection(left.shape(), right.shape());
         Set<Class<?>> notBroadcastedDimensions = Sets.union(dimensionalIntersection, excludedDimensions)
                 .immutableCopy();
 
         Shape missingLeft = dimensionStripped(right.shape(), notBroadcastedDimensions);
         Shape missingRight = dimensionStripped(left.shape(), notBroadcastedDimensions);
 
-        return TensorPair.fromLeftRight(new BroadcastedTensorView<V>(left, missingLeft), new BroadcastedTensorView<V>(
-                right, missingRight));
+        return TensorPair.fromLeftRight(new BroadcastedTensorView<V>(left, missingLeft),
+                new BroadcastedTensorView<V>(right, missingRight));
     }
 
     @Override

--- a/src/test/org/tensorics/core/tensor/CoordinateClassHierarchyTest.java
+++ b/src/test/org/tensorics/core/tensor/CoordinateClassHierarchyTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2017 European Organisation for Nuclear Research (CERN), All Rights Reserved.
+ */
+
+package org.tensorics.core.tensor;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.tensorics.core.lang.DoubleTensorics;
+import org.tensorics.core.lang.Tensorics;
+
+import com.google.common.collect.ImmutableSet;
+
+public class CoordinateClassHierarchyTest {
+    public interface FirstCoordinateInterface {
+        /* marker interface */
+    }
+
+    public enum FirstCoordinate implements FirstCoordinateInterface {
+        FIRST_1,
+        FIRST_2,
+        FIRST_3;
+    }
+
+    public enum IncompatibleFirstCoordinate implements FirstCoordinateInterface {
+        INCOMPATIBLEFIRST_1,
+        INCOMPATIBLEFIRST_2;
+    }
+
+    public enum SecondCoordinate {
+        SECOND_1,
+        SECOND_2;
+    }
+
+    private static Tensor<Double> buildTensorFor(Class<? extends Enum<?>> first, Class<? extends Enum<?>> second,
+            Class<?>... dimensions) {
+        TensorBuilder<Double> builder = Tensorics.builder(dimensions);
+        for (Object firstCoordinate : first.getEnumConstants()) {
+            for (Object secondCoordinate : second.getEnumConstants()) {
+                builder.putAt(1.0, firstCoordinate, secondCoordinate);
+            }
+        }
+        return builder.build();
+    }
+
+    private final Tensor<Double> leafClassTensor = buildTensorFor(FirstCoordinate.class, SecondCoordinate.class,
+            FirstCoordinate.class, SecondCoordinate.class);
+    private final Tensor<Double> compatibleInterfaceTensor = buildTensorFor(FirstCoordinate.class,
+            SecondCoordinate.class, FirstCoordinateInterface.class, SecondCoordinate.class);
+    private final Tensor<Double> incompatibleLeafTensor = buildTensorFor(IncompatibleFirstCoordinate.class,
+            SecondCoordinate.class, IncompatibleFirstCoordinate.class, SecondCoordinate.class);
+    private final Tensor<Double> incompatibleInterfaceTensor = buildTensorFor(IncompatibleFirstCoordinate.class,
+            SecondCoordinate.class, FirstCoordinateInterface.class, SecondCoordinate.class);
+
+    @Test
+    public void shapeIsConservedInCalculation() {
+        Tensor<Double> leafResult = DoubleTensorics.calculate(leafClassTensor).plus(leafClassTensor);
+        assertEquals(leafClassTensor.shape(), leafResult.shape());
+        Tensor<Double> interfaceResult = DoubleTensorics.calculate(compatibleInterfaceTensor)
+                .plus(compatibleInterfaceTensor);
+        assertEquals(compatibleInterfaceTensor.shape(), interfaceResult.shape());
+    }
+
+    @Test
+    public void canBroadcastForTensorsWithIncompatibleDimensions() {
+        Tensor<Double> result = DoubleTensorics.calculate(leafClassTensor).plus(incompatibleLeafTensor);
+        assertEquals(ImmutableSet.of(FirstCoordinate.class, SecondCoordinate.class, IncompatibleFirstCoordinate.class),
+                result.shape().dimensionSet());
+    }
+
+    @Test
+    public void canAddTensorsWithCompatibleDimensionsAndCompatibleLeafCoordinates() {
+        Tensor<Double> result = DoubleTensorics.calculate(leafClassTensor).plus(compatibleInterfaceTensor);
+        assertEquals(compatibleInterfaceTensor.shape(), result.shape());
+    }
+
+    @Test
+    public void canAddTensorsWithCompatibleDimensionsAndIncompatibleLeafCoordinates() {
+        Tensor<Double> result = DoubleTensorics.calculate(leafClassTensor).plus(incompatibleInterfaceTensor);
+        assertEquals(incompatibleInterfaceTensor.shape().dimensionSet(), result.shape().dimensionSet());
+        result = DoubleTensorics.calculate(incompatibleInterfaceTensor).plus(leafClassTensor);
+        assertEquals(incompatibleInterfaceTensor.shape().dimensionSet(), result.shape().dimensionSet());
+    }
+
+    @Test
+    public void canAddTensorsWithEqualDimensionsAndIncompatibleLeafCoordinates() {
+        Tensor<Double> result = DoubleTensorics.calculate(compatibleInterfaceTensor).plus(incompatibleInterfaceTensor);
+        assertEquals(compatibleInterfaceTensor.shape().dimensionSet(), result.shape().dimensionSet());
+        assertEquals(0, result.shape().size());
+    }
+
+    @Test
+    public void canCompleteTensorsWithCompatibleDimensionsAndIncompatibleLeafCoordinates() {
+        Tensorics.complete(compatibleInterfaceTensor).with(incompatibleInterfaceTensor);
+    }
+
+    @Test
+    public void canAddTensorsWithEqualDimensionsAndPartiallyIncompatibleLeafCoordinates() {
+        Tensor<Double> mixedInterfaceTensor = Tensorics.complete(compatibleInterfaceTensor)
+                .with(incompatibleInterfaceTensor);
+        Tensor<Double> result = DoubleTensorics.calculate(compatibleInterfaceTensor).plus(mixedInterfaceTensor);
+        assertEquals(compatibleInterfaceTensor.shape().dimensionSet(), result.shape().dimensionSet());
+        assertEquals(6, result.shape().size());
+    }
+
+}

--- a/src/test/org/tensorics/core/tensor/CoordinatesTest.java
+++ b/src/test/org/tensorics/core/tensor/CoordinatesTest.java
@@ -21,12 +21,17 @@
 // @formatter:on
 package org.tensorics.core.tensor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.tensorics.core.testing.TestUtil.assertUtilityClass;
 
 import java.util.HashSet;
 import java.util.Set;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
+
+import com.google.common.collect.ImmutableSet;
 
 public class CoordinatesTest {
 
@@ -91,6 +96,29 @@ public class CoordinatesTest {
         coordinates.add(IB.class);
         coordinates.add(IE.class);
         Coordinates.checkClassesRelations(coordinates);
+    }
+
+    @Test
+    public void parentClassIntersection() {
+        ImmutableSet<Class<?>> leftCoordinates = ImmutableSet.of(A.class, IB.class);
+        ImmutableSet<Class<?>> rightCoordinates = ImmutableSet.of(IA.class, B.class);
+        Set<Class<?>> result = Coordinates.parentClassIntersection(leftCoordinates, rightCoordinates);
+        assertThat(result).containsExactlyInAnyOrder(IA.class, IB.class);
+    }
+
+    @Test(expected=IllegalArgumentException.class)
+    public void parentClassObjectIntersection() {
+        ImmutableSet<Class<?>> leftCoordinates = ImmutableSet.of(A.class, B.class);
+        ImmutableSet<Class<?>> rightCoordinates = ImmutableSet.of(Object.class);
+        Coordinates.parentClassIntersection(leftCoordinates, rightCoordinates);
+    }
+
+    @Test
+    public void parentClassIntersectionDifferentSets() {
+        ImmutableSet<Class<?>> leftCoordinates = ImmutableSet.of(A.class, B.class);
+        ImmutableSet<Class<?>> rightCoordinates = ImmutableSet.of(C.class);
+        Set<Class<?>> result = Coordinates.parentClassIntersection(leftCoordinates, rightCoordinates);
+        assertThat(result).isEmpty();
     }
 
     interface IA {

--- a/src/test/org/tensorics/core/tensor/ShapesTest.java
+++ b/src/test/org/tensorics/core/tensor/ShapesTest.java
@@ -23,6 +23,7 @@
 package org.tensorics.core.tensor;
 
 import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -35,6 +36,7 @@ import static org.tensorics.core.testing.TestUtil.assertUtilityClass;
 import java.util.Collections;
 import java.util.Set;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -101,12 +103,16 @@ public class ShapesTest {
 
     @Test
     public void emptyShapeIterable() {
-        assertEmptyShape(Shape.of(Collections.<Position> emptySet()));
+        Shape shape = Shape.of(Collections.<Position> emptySet());
+        assertEmptyShape(shape);
+        assertZeroDimensionality(shape);
     }
 
     @Test
     public void constructEmptyShapeUsingVarargs() {
-        assertEmptyShape(Shape.empty());
+        Shape shape = Shape.empty();
+        assertEmptyShape(shape);
+        assertZeroDimensionality(shape);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -116,7 +122,9 @@ public class ShapesTest {
 
     @Test
     public void intersectionOfCompatibleShapesWithEmptyResult() {
-        assertEmptyShape(intersection(shapeA, shapeB));
+        Shape intersection = intersection(shapeA, shapeB);
+        assertEmptyShape(intersection);
+        assertThat(intersection.dimensionSet()).containsExactly(String.class);
     }
 
     @Test
@@ -245,8 +253,11 @@ public class ShapesTest {
 
     private static void assertEmptyShape(Shape shape) {
         assertEquals(0, shape.size());
-        assertEquals(0, shape.dimensionality());
         assertEquals(emptySet(), shape.positionSet());
+    }
+    
+    private static void assertZeroDimensionality(Shape shape) {
+        assertEquals(0, shape.dimensionality());
         assertEquals(emptySet(), shape.dimensionSet());
     }
 


### PR DESCRIPTION
Fix some bugs in handling of interfaces/superclasses as dimensions. In particular:
* make sure that the dimensions are retained throughout a calculation (don't infer them from the positions during the calculation)
* fix the broadcasting and shaping strategies to take into account the class hierarchies
* make sure that operations can be done on tensors with compatible dimensions, e.g. one tensor with an interface dimension and another with an implementation dimension. The result will be a tensor of the interface dimension in this case.