### PR TITLE
Introduce scalar

### DIFF
--- a/src/examples/org/tensorics/core/examples/MultibeamOrbit.java
+++ b/src/examples/org/tensorics/core/examples/MultibeamOrbit.java
@@ -16,12 +16,12 @@ import org.tensorics.core.tensorbacked.orbit.coordinates.Plane;
  * 
  * @author agorzaws
  */
-//tag::classdef[]
+// tag::classdef[]
 @Dimensions({ Beam.class, Plane.class, Bpm.class })
 public class MultibeamOrbit implements Tensorbacked<Double> {
 
     private final Tensor<Double> tensor;
-    
+
     public MultibeamOrbit(Tensor<Double> tensor) {
         this.tensor = tensor;
     }
@@ -36,5 +36,4 @@ public class MultibeamOrbit implements Tensorbacked<Double> {
     }
 
 }
-//end::classdef[]
-
+// end::classdef[]

--- a/src/examples/org/tensorics/core/examples/Signal.java
+++ b/src/examples/org/tensorics/core/examples/Signal.java
@@ -7,20 +7,20 @@ package org.tensorics.core.examples;
 /**
  * Dummy signal
  * 
- * @author kfuchsbe 
+ * @author kfuchsbe
  */
 public final class Signal {
 
     final String name;
-    
+
     public static Signal of(String name) {
         return new Signal(name);
     }
-    
+
     private Signal(String name) {
         this.name = name;
     }
-    
+
     String getName() {
         return name;
     }

--- a/src/examples/org/tensorics/core/examples/WorkingWithTensors.java
+++ b/src/examples/org/tensorics/core/examples/WorkingWithTensors.java
@@ -6,8 +6,8 @@ import org.tensorics.core.lang.Tensorics;
 
 @SuppressWarnings("unused")
 public class WorkingWithTensors {
-	{
-		TensoricSupport<Double> support = Tensorics.using(Structures.doubles());
+    {
+        TensoricSupport<Double> support = Tensorics.using(Structures.doubles());
 
-	}
+    }
 }

--- a/src/examples/org/tensorics/core/examples/meteo/domain/City.java
+++ b/src/examples/org/tensorics/core/examples/meteo/domain/City.java
@@ -5,8 +5,8 @@ import org.tensorics.core.examples.meteo.domain.coordinates.Longitude;
 
 public interface City {
 
-	Longitude getLongitude();
+    Longitude getLongitude();
 
-	Latitude getLatitude();
+    Latitude getLatitude();
 
 }

--- a/src/examples/org/tensorics/core/examples/meteo/domain/EuropeanCapital.java
+++ b/src/examples/org/tensorics/core/examples/meteo/domain/EuropeanCapital.java
@@ -5,33 +5,33 @@ import org.tensorics.core.examples.meteo.domain.coordinates.Longitude;
 
 public enum EuropeanCapital implements City {
 
-	BERLIN(new Longitude(65.00), new Latitude(12.12)),
+    BERLIN(new Longitude(65.00), new Latitude(12.12)),
 
-	PARIS(new Longitude(75.00), new Latitude(13.92)),
+    PARIS(new Longitude(75.00), new Latitude(13.92)),
 
-	WARSZAWA(new Longitude(65.50), new Latitude(24.12)),
+    WARSZAWA(new Longitude(65.50), new Latitude(24.12)),
 
-	BERN(new Longitude(73.00), new Latitude(42.2)),
+    BERN(new Longitude(73.00), new Latitude(42.2)),
 
-	LONDON(new Longitude(62.00), new Latitude(13.77)), 
-	
-	ROMA(new Longitude(52.00), new Latitude(13.77));
+    LONDON(new Longitude(62.00), new Latitude(13.77)),
 
-	private Longitude longitude;
-	private Latitude latitude;
+    ROMA(new Longitude(52.00), new Latitude(13.77));
 
-	private EuropeanCapital(Longitude longitude, Latitude latitude) {
-		this.latitude = latitude;
-		this.longitude = longitude;
-	}
+    private Longitude longitude;
+    private Latitude latitude;
 
-	@Override
-	public Longitude getLongitude() {
-		return longitude;
-	}
+    private EuropeanCapital(Longitude longitude, Latitude latitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
 
-	@Override
-	public Latitude getLatitude() {
-		return latitude;
-	}
+    @Override
+    public Longitude getLongitude() {
+        return longitude;
+    }
+
+    @Override
+    public Latitude getLatitude() {
+        return latitude;
+    }
 }

--- a/src/examples/org/tensorics/core/examples/meteo/domain/Pressure.java
+++ b/src/examples/org/tensorics/core/examples/meteo/domain/Pressure.java
@@ -6,15 +6,15 @@ import org.tensorics.core.tensorbacked.Tensorbacked;
 
 public class Pressure implements Tensorbacked<QuantifiedValue<Double>> {
 
-	private final Tensor<QuantifiedValue<Double>> temperature;
-	
-	public Pressure(Tensor<QuantifiedValue<Double>> temperature) {
-		this.temperature = temperature;
-	}
+    private final Tensor<QuantifiedValue<Double>> temperature;
 
-	@Override
-	public Tensor<QuantifiedValue<Double>> tensor() {
-		return temperature;
-	}
+    public Pressure(Tensor<QuantifiedValue<Double>> temperature) {
+        this.temperature = temperature;
+    }
+
+    @Override
+    public Tensor<QuantifiedValue<Double>> tensor() {
+        return temperature;
+    }
 
 }

--- a/src/examples/org/tensorics/core/examples/meteo/domain/Sampling.java
+++ b/src/examples/org/tensorics/core/examples/meteo/domain/Sampling.java
@@ -1,5 +1,8 @@
 package org.tensorics.core.examples.meteo.domain;
 
 public enum Sampling {
-	ONE_DAY, ONE_WEEK, ONE_HOUR, ONE_SECOND
+    ONE_DAY,
+    ONE_WEEK,
+    ONE_HOUR,
+    ONE_SECOND
 }

--- a/src/examples/org/tensorics/core/examples/meteo/domain/Temperature.java
+++ b/src/examples/org/tensorics/core/examples/meteo/domain/Temperature.java
@@ -8,19 +8,18 @@ import org.tensorics.core.tensor.Tensor;
 import org.tensorics.core.tensorbacked.Tensorbacked;
 import org.tensorics.core.tensorbacked.annotation.Dimensions;
 
-
-@Dimensions({Latitude.class, Longitude.class, Time.class})
+@Dimensions({ Latitude.class, Longitude.class, Time.class })
 public class Temperature implements Tensorbacked<QuantifiedValue<Double>> {
 
-	private final Tensor<QuantifiedValue<Double>> temperature;
-	
-	public Temperature(Tensor<QuantifiedValue<Double>> temperature) {
-		this.temperature = temperature;
-	}
+    private final Tensor<QuantifiedValue<Double>> temperature;
 
-	@Override
-	public Tensor<QuantifiedValue<Double>> tensor() {
-		return temperature;
-	}
+    public Temperature(Tensor<QuantifiedValue<Double>> temperature) {
+        this.temperature = temperature;
+    }
+
+    @Override
+    public Tensor<QuantifiedValue<Double>> tensor() {
+        return temperature;
+    }
 
 }

--- a/src/examples/org/tensorics/core/examples/meteo/domain/TimeRange.java
+++ b/src/examples/org/tensorics/core/examples/meteo/domain/TimeRange.java
@@ -2,6 +2,11 @@ package org.tensorics.core.examples.meteo.domain;
 
 public enum TimeRange {
 
-	TWO_DECADES, A_DECADE, FIVE_YEARS, A_YEAR, SIX_MONTHS, A_MONTH
+    TWO_DECADES,
+    A_DECADE,
+    FIVE_YEARS,
+    A_YEAR,
+    SIX_MONTHS,
+    A_MONTH
 
 }

--- a/src/examples/org/tensorics/core/examples/meteo/domain/coordinates/Latitude.java
+++ b/src/examples/org/tensorics/core/examples/meteo/domain/coordinates/Latitude.java
@@ -1,45 +1,44 @@
 package org.tensorics.core.examples.meteo.domain.coordinates;
 
-public class Latitude implements MeteoCoordinate{
-	private double lattitude;
+public class Latitude implements MeteoCoordinate {
+    private double lattitude;
 
-	public Latitude(double lattitude) {
-		super();
-		this.lattitude = lattitude;
-	}
+    public Latitude(double lattitude) {
+        super();
+        this.lattitude = lattitude;
+    }
 
-	public double getLattitude() {
-		return lattitude;
-	}
+    public double getLattitude() {
+        return lattitude;
+    }
 
-	@Override
-	public String toString() {
-		return "[lattitude=" + lattitude + "]";
-	}
+    @Override
+    public String toString() {
+        return "[lattitude=" + lattitude + "]";
+    }
 
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		long temp;
-		temp = Double.doubleToLongBits(lattitude);
-		result = prime * result + (int) (temp ^ (temp >>> 32));
-		return result;
-	}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        long temp;
+        temp = Double.doubleToLongBits(lattitude);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        return result;
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		Latitude other = (Latitude) obj;
-		if (Double.doubleToLongBits(lattitude) != Double
-				.doubleToLongBits(other.lattitude))
-			return false;
-		return true;
-	}
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Latitude other = (Latitude) obj;
+        if (Double.doubleToLongBits(lattitude) != Double.doubleToLongBits(other.lattitude))
+            return false;
+        return true;
+    }
 
 }

--- a/src/examples/org/tensorics/core/examples/meteo/domain/coordinates/Longitude.java
+++ b/src/examples/org/tensorics/core/examples/meteo/domain/coordinates/Longitude.java
@@ -1,45 +1,44 @@
 package org.tensorics.core.examples.meteo.domain.coordinates;
 
-public class Longitude implements MeteoCoordinate{
-	@Override
-	public String toString() {
-		return "[longitude=" + longitude + "]";
-	}
+public class Longitude implements MeteoCoordinate {
+    @Override
+    public String toString() {
+        return "[longitude=" + longitude + "]";
+    }
 
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		long temp;
-		temp = Double.doubleToLongBits(longitude);
-		result = prime * result + (int) (temp ^ (temp >>> 32));
-		return result;
-	}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        long temp;
+        temp = Double.doubleToLongBits(longitude);
+        result = prime * result + (int) (temp ^ (temp >>> 32));
+        return result;
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		Longitude other = (Longitude) obj;
-		if (Double.doubleToLongBits(longitude) != Double
-				.doubleToLongBits(other.longitude))
-			return false;
-		return true;
-	}
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Longitude other = (Longitude) obj;
+        if (Double.doubleToLongBits(longitude) != Double.doubleToLongBits(other.longitude))
+            return false;
+        return true;
+    }
 
-	private double longitude;
+    private double longitude;
 
-	public double getLongitude() {
-		return longitude;
-	}
+    public double getLongitude() {
+        return longitude;
+    }
 
-	public Longitude(double longitude) {
-		super();
-		this.longitude = longitude;
-	}
+    public Longitude(double longitude) {
+        super();
+        this.longitude = longitude;
+    }
 
 }

--- a/src/examples/org/tensorics/core/examples/meteo/domain/coordinates/MeteoCoordinate.java
+++ b/src/examples/org/tensorics/core/examples/meteo/domain/coordinates/MeteoCoordinate.java
@@ -4,8 +4,7 @@ package org.tensorics.core.examples.meteo.domain.coordinates;
  * A marker interface for coordinate classes
  * 
  * @author arek
- * 
  */
 public interface MeteoCoordinate {
-	/* marker interface for coordinate */
+    /* marker interface for coordinate */
 }

--- a/src/examples/org/tensorics/core/examples/meteo/domain/coordinates/Time.java
+++ b/src/examples/org/tensorics/core/examples/meteo/domain/coordinates/Time.java
@@ -3,46 +3,46 @@ package org.tensorics.core.examples.meteo.domain.coordinates;
 import java.util.Date;
 
 public class Time implements MeteoCoordinate {
-	private long time;
+    private long time;
 
-	public Time(long time) {
-		super();
-		this.time = time;
-	}
+    public Time(long time) {
+        super();
+        this.time = time;
+    }
 
-	public Time() {
-		this(new Date().getTime());
-	}
+    public Time() {
+        this(new Date().getTime());
+    }
 
-	public long getTime() {
-		return time;
-	}
+    public long getTime() {
+        return time;
+    }
 
-	@Override
-	public String toString() {
-		return "[time=" + time + "]";
-	}
+    @Override
+    public String toString() {
+        return "[time=" + time + "]";
+    }
 
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + (int) (time ^ (time >>> 32));
-		return result;
-	}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + (int) (time ^ (time >>> 32));
+        return result;
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		Time other = (Time) obj;
-		if (time != other.time)
-			return false;
-		return true;
-	}
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Time other = (Time) obj;
+        if (time != other.time)
+            return false;
+        return true;
+    }
 
 }

--- a/src/examples/org/tensorics/core/examples/meteo/history/AbstractWeatherHistory.java
+++ b/src/examples/org/tensorics/core/examples/meteo/history/AbstractWeatherHistory.java
@@ -14,18 +14,17 @@ import org.tensorics.core.tensor.options.IntersectionShapingStrategy;
 
 public abstract class AbstractWeatherHistory extends TensoricSupport<Double> {
 
-	public AbstractWeatherHistory() {
-		super(EnvironmentImpl.of(Structures.doubles(),
-				ManipulationOptions.defaultOptions(Structures.doubles())).with(
-				new IntersectionShapingStrategy()));
-	}
+    public AbstractWeatherHistory() {
+        super(EnvironmentImpl.of(Structures.doubles(), ManipulationOptions.defaultOptions(Structures.doubles()))
+                .with(new IntersectionShapingStrategy()));
+    }
 
-	public abstract List<City> getCities();
+    public abstract List<City> getCities();
 
-	// tag::import[]
-	public Tensor<QuantifiedValue<Double>> importDataForCities() {
-		return FakeMeteoDataImporter.importFromPast();
-	}
-	// end::import[]
+    // tag::import[]
+    public Tensor<QuantifiedValue<Double>> importDataForCities() {
+        return FakeMeteoDataImporter.importFromPast();
+    }
+    // end::import[]
 
 }

--- a/src/examples/org/tensorics/core/examples/meteo/history/WeatherHistoryInEurope.java
+++ b/src/examples/org/tensorics/core/examples/meteo/history/WeatherHistoryInEurope.java
@@ -17,33 +17,33 @@ import org.tensorics.core.tensor.Tensor;
 
 public class WeatherHistoryInEurope extends AbstractWeatherHistory {
 
-	@Override
-	public List<City> getCities() {
-		return Arrays.<City> asList(EuropeanCapital.values());
-	}
+    @Override
+    public List<City> getCities() {
+        return Arrays.<City> asList(EuropeanCapital.values());
+    }
 
-	// tag::import[]
+    // tag::import[]
 
-	/* calculate an average monthly temperature at the ROME Latitude like cities */
-	@SuppressWarnings("unused")
+    /* calculate an average monthly temperature at the ROME Latitude like cities */
+    @SuppressWarnings("unused")
     public void calculate() {
 
-		Tensor<QuantifiedValue<Double>> importedData = importDataForCities();
-		Latitude romeLatitude = EuropeanCapital.ROMA.getLatitude();
-		Tensor<QuantifiedValue<Double>> sliceAtTropicCancerAndRome = from(importedData).extract(romeLatitude);
+        Tensor<QuantifiedValue<Double>> importedData = importDataForCities();
+        Latitude romeLatitude = EuropeanCapital.ROMA.getLatitude();
+        Tensor<QuantifiedValue<Double>> sliceAtTropicCancerAndRome = from(importedData).extract(romeLatitude);
 
-		Temperature temperature = new Temperature(importedData);
+        Temperature temperature = new Temperature(importedData);
 
-		Tensor<QuantifiedValue<Double>> elementTimes = calculateQ(importedData).elementTimes(importedData);
-		Temperature elementTimes2 = calculateQ(temperature).elementTimes(temperature);
+        Tensor<QuantifiedValue<Double>> elementTimes = calculateQ(importedData).elementTimes(importedData);
+        Temperature elementTimes2 = calculateQ(temperature).elementTimes(temperature);
 
-		/* dimension will be reduced to only Longitude and Time */
-		sliceAtTropicCancerAndRome.shape().dimensionSet();
-		//
-		// from(sliceAtTropicCancerAndRome).reduce(Time.class).byAveragingIn(field)
+        /* dimension will be reduced to only Longitude and Time */
+        sliceAtTropicCancerAndRome.shape().dimensionSet();
+        //
+        // from(sliceAtTropicCancerAndRome).reduce(Time.class).byAveragingIn(field)
 
-		TensoricSupport<Double> fullTensoricSupport = Tensorics.using(Structures.doubles());
+        TensoricSupport<Double> fullTensoricSupport = Tensorics.using(Structures.doubles());
 
-	}
-	// end::import[]
+    }
+    // end::import[]
 }

--- a/src/examples/org/tensorics/core/examples/meteo/simple/City.java
+++ b/src/examples/org/tensorics/core/examples/meteo/simple/City.java
@@ -1,8 +1,8 @@
 package org.tensorics.core.examples.meteo.simple;
 
-//tag::cityEnum[]
+// tag::cityEnum[]
 public enum City {
-	NEW_YORK, 
-	GENEVA;
+    NEW_YORK,
+    GENEVA;
 }
-//end::cityEnum[]
+// end::cityEnum[]

--- a/src/examples/org/tensorics/core/examples/meteo/simple/Day.java
+++ b/src/examples/org/tensorics/core/examples/meteo/simple/Day.java
@@ -1,8 +1,8 @@
 package org.tensorics.core.examples.meteo.simple;
 
-//tag::dayEnum[]
+// tag::dayEnum[]
 public enum Day {
-	APRIL_1_2014, 
-	JUNE_1_2014;
+    APRIL_1_2014,
+    JUNE_1_2014;
 }
-//end::dayEnum[]
+// end::dayEnum[]

--- a/src/examples/org/tensorics/core/examples/scripting/ScriptingExample.java
+++ b/src/examples/org/tensorics/core/examples/scripting/ScriptingExample.java
@@ -12,58 +12,56 @@ import com.google.common.collect.ImmutableList;
 
 public class ScriptingExample {
 
-	private double someFactorForFakingChangingEnvironment = 1.0;
-	private final Expression<Iterable<Double>> someFakeIterable = fakeSignalByCreationCallback();
+    private double someFactorForFakingChangingEnvironment = 1.0;
+    private final Expression<Iterable<Double>> someFakeIterable = fakeSignalByCreationCallback();
 
-	private final DoubleScript<Double> script = new DoubleScript<Double>() {
+    private final DoubleScript<Double> script = new DoubleScript<Double>() {
 
-		@Override
-		public Expression<Double> describe() {
-			Expression<Double> average = averageOf(someFakeIterable);
-			Expression<Double> rms = rmsOf(someFakeIterable);
-			Expression<Double> size = sizeOf(someFakeIterable);
-			Expression<Double> someNonesenseValue = calculate(average).plus(rms);
-			Expression<Double> anotherNonsense = calculate(someNonesenseValue).times(size);
-			return calculate(anotherNonsense).minus(2.0);
-		}
+        @Override
+        public Expression<Double> describe() {
+            Expression<Double> average = averageOf(someFakeIterable);
+            Expression<Double> rms = rmsOf(someFakeIterable);
+            Expression<Double> size = sizeOf(someFakeIterable);
+            Expression<Double> someNonesenseValue = calculate(average).plus(rms);
+            Expression<Double> anotherNonsense = calculate(someNonesenseValue).times(size);
+            return calculate(anotherNonsense).minus(2.0);
+        }
 
-	};
+    };
 
-	private ResolvingEngine engine = ResolvingEngines.defaultEngine();
+    private ResolvingEngine engine = ResolvingEngines.defaultEngine();
 
-	@Test
-	public void resolveScriptWithDifferentConditions() {
-		someFactorForFakingChangingEnvironment = 1.0;
-		Double result1 = engine.resolve(script);
-		System.out.println(result1);
+    @Test
+    public void resolveScriptWithDifferentConditions() {
+        someFactorForFakingChangingEnvironment = 1.0;
+        Double result1 = engine.resolve(script);
+        System.out.println(result1);
 
-		someFactorForFakingChangingEnvironment = 2.0;
-		Double result2 = engine.resolve(script);
-		System.out.println(result2);
+        someFactorForFakingChangingEnvironment = 2.0;
+        Double result2 = engine.resolve(script);
+        System.out.println(result2);
 
-		someFactorForFakingChangingEnvironment = 1.0;
-		Expression<Double> expression = script.getInternalExpression();
-		Double result3 = engine.resolve(expression);
-		System.out.println(result3);
-	}
+        someFactorForFakingChangingEnvironment = 1.0;
+        Expression<Double> expression = script.getInternalExpression();
+        Double result3 = engine.resolve(expression);
+        System.out.println(result3);
+    }
 
-	private final Expression<Iterable<Double>> fakeSignalByCreationCallback() {
-		/*
-		 * A creation operation expression most probably maps to an akka source
-		 * (which again might correspond more or leass to a StreamId in the new
-		 * streaming layer)
-		 */
-		return new CreationOperationExpression<>(new CreationOperation<Iterable<Double>>() {
-			@Override
-			public Iterable<Double> perform() {
-				/*
-				 * In reality, one could e.g. look up a real signal here, or
-				 * write some dedicated expression instead of the
-				 * CreationOperation.
-				 */
-				return ImmutableList.of(1.0 * someFactorForFakingChangingEnvironment,
-						2.0 * someFactorForFakingChangingEnvironment, 3.0 * someFactorForFakingChangingEnvironment);
-			}
-		});
-	}
+    private final Expression<Iterable<Double>> fakeSignalByCreationCallback() {
+        /*
+         * A creation operation expression most probably maps to an akka source (which again might correspond more or
+         * leass to a StreamId in the new streaming layer)
+         */
+        return new CreationOperationExpression<>(new CreationOperation<Iterable<Double>>() {
+            @Override
+            public Iterable<Double> perform() {
+                /*
+                 * In reality, one could e.g. look up a real signal here, or write some dedicated expression instead of
+                 * the CreationOperation.
+                 */
+                return ImmutableList.of(1.0 * someFactorForFakingChangingEnvironment,
+                        2.0 * someFactorForFakingChangingEnvironment, 3.0 * someFactorForFakingChangingEnvironment);
+            }
+        });
+    }
 }

--- a/src/examples/org/tensorics/core/examples/sprint/NumberOfDay.java
+++ b/src/examples/org/tensorics/core/examples/sprint/NumberOfDay.java
@@ -34,5 +34,4 @@ public class NumberOfDay {
         return true;
     }
 
-    
 }

--- a/src/examples/org/tensorics/core/examples/sprint/SprintExample.java
+++ b/src/examples/org/tensorics/core/examples/sprint/SprintExample.java
@@ -22,79 +22,79 @@ import com.google.common.collect.ImmutableSet;
 
 public class SprintExample extends TensoricDoubleSupport {
 
-	private static final Team TEAM_1 = new Team(1);
-	private static final Team TEAM_3 = new Team(3);
+    private static final Team TEAM_1 = new Team(1);
+    private static final Team TEAM_3 = new Team(3);
 
-	private Tensor<Double> velocity;
-	private Tensor<Double> focusFactor;
-	private Tensor<Double> team1Velocity;
-	private Tensor<Double> team3Velocity;
-	private Tensor<Double> mergedTensor;
+    private Tensor<Double> velocity;
+    private Tensor<Double> focusFactor;
+    private Tensor<Double> team1Velocity;
+    private Tensor<Double> team3Velocity;
+    private Tensor<Double> mergedTensor;
 
-	@Before
-	public void setUp() {
-		TensorBuilder<Double> velocityBuilder = builder(Team.class, NumberOfDay.class);
-		TensorBuilder<Double> focusFactorBuilder = Tensorics.builder(Team.class);
+    @Before
+    public void setUp() {
+        TensorBuilder<Double> velocityBuilder = builder(Team.class, NumberOfDay.class);
+        TensorBuilder<Double> focusFactorBuilder = Tensorics.builder(Team.class);
 
-		Random random = new Random();
+        Random random = new Random();
 
-		for (int teamId = 1; teamId <= 10; teamId++) {
-			Team team = new Team(teamId);
-			focusFactorBuilder.putAt(random.nextDouble(), team);
-			for (int days = 1; days <= 20; days++) {
-				velocityBuilder.putAt(10 * random.nextDouble(), team, new NumberOfDay(days));
-			}
-		}
-		velocity = velocityBuilder.build();
-		focusFactor = focusFactorBuilder.build();
+        for (int teamId = 1; teamId <= 10; teamId++) {
+            Team team = new Team(teamId);
+            focusFactorBuilder.putAt(random.nextDouble(), team);
+            for (int days = 1; days <= 20; days++) {
+                velocityBuilder.putAt(10 * random.nextDouble(), team, new NumberOfDay(days));
+            }
+        }
+        velocity = velocityBuilder.build();
+        focusFactor = focusFactorBuilder.build();
 
-		team1Velocity = from(velocity).extract(TEAM_1);
-		team3Velocity = from(velocity).extract(TEAM_3);
+        team1Velocity = from(velocity).extract(TEAM_1);
+        team3Velocity = from(velocity).extract(TEAM_3);
 
-		mergedTensor = Tensorics.merge(ImmutableSet.of(team1Velocity, team3Velocity));
-	}
+        mergedTensor = Tensorics.merge(ImmutableSet.of(team1Velocity, team3Velocity));
+    }
 
-	@Test
-	public void testApplyVelocity() {
-		Tensor<Double> alteredVelocity = calculate(velocity).elementTimes(focusFactor);
+    @Test
+    public void testApplyVelocity() {
+        Tensor<Double> alteredVelocity = calculate(velocity).elementTimes(focusFactor);
 
-		assertEquals(velocity.shape(), alteredVelocity.shape());
-		for (Position position : velocity.shape().positionSet()) {
-			Double velocityValue = velocity.get(position);
-			Double focusFactorValue = focusFactor.get(position.coordinateFor(Team.class));
-			Double alteredVelocityValue = alteredVelocity.get(position);
-			assertEquals(velocityValue * focusFactorValue, alteredVelocityValue, 0);
-		}
-	}
+        assertEquals(velocity.shape(), alteredVelocity.shape());
+        for (Position position : velocity.shape().positionSet()) {
+            Double velocityValue = velocity.get(position);
+            Double focusFactorValue = focusFactor.get(position.coordinateFor(Team.class));
+            Double alteredVelocityValue = alteredVelocity.get(position);
+            assertEquals(velocityValue * focusFactorValue, alteredVelocityValue, 0);
+        }
+    }
 
-	@Test
-	public void testMergeEqualsPutAll() {
-		TensorBuilder<Double> putAllTensorBuilder = builder(Team.class, NumberOfDay.class);
-		putAllTensorBuilder.putAllAt(team1Velocity, TEAM_1);
-		putAllTensorBuilder.putAllAt(team3Velocity, TEAM_3);
-		Tensor<Double> putAllTensor = putAllTensorBuilder.build();
+    @Test
+    public void testMergeEqualsPutAll() {
+        TensorBuilder<Double> putAllTensorBuilder = builder(Team.class, NumberOfDay.class);
+        putAllTensorBuilder.putAllAt(team1Velocity, TEAM_1);
+        putAllTensorBuilder.putAllAt(team3Velocity, TEAM_3);
+        Tensor<Double> putAllTensor = putAllTensorBuilder.build();
 
-		assertEquals(putAllTensor, mergedTensor);
-	}
+        assertEquals(putAllTensor, mergedTensor);
+    }
 
-	@Test
-	public void testIfMergedTensorHasCorrectSize() {
-		int differentNumberOfDays = velocity.shape().coordinatesOfType(NumberOfDay.class).size();
-		int numberOfTeams = mergedTensor.shape().coordinatesOfType(Team.class).size();
-		Tensor<Double> smallerTensor = calculate(velocity).times(mergedTensor);
-		int expectedSize = differentNumberOfDays * numberOfTeams;
-		assertEquals(expectedSize, mergedTensor.shape().size());
-		assertEquals(expectedSize, smallerTensor.shape().size());
-	}
+    @Test
+    public void testIfMergedTensorHasCorrectSize() {
+        int differentNumberOfDays = velocity.shape().coordinatesOfType(NumberOfDay.class).size();
+        int numberOfTeams = mergedTensor.shape().coordinatesOfType(Team.class).size();
+        Tensor<Double> smallerTensor = calculate(velocity).times(mergedTensor);
+        int expectedSize = differentNumberOfDays * numberOfTeams;
+        assertEquals(expectedSize, mergedTensor.shape().size());
+        assertEquals(expectedSize, smallerTensor.shape().size());
+    }
 
-	@Test
-	public void testContext() {
-		Position team1Context = team1Velocity.context();
-		assertEquals(1, team1Context.coordinates().size());
+    @Test
+    public void testContext() {
+        Position team1Context = team1Velocity.context();
+        assertEquals(1, team1Context.coordinates().size());
 
-		Tensor<Double> sliceAtOneDay = from(team1Velocity).extract(new NumberOfDay(1));
-		Position oneDayContext = sliceAtOneDay.context();
-		assertEquals(2, oneDayContext.coordinates().size());
-	}
+        Tensor<Double> sliceAtOneDay = from(team1Velocity).extract(new NumberOfDay(1));
+        Position oneDayContext = sliceAtOneDay.context();
+        assertEquals(2, oneDayContext.coordinates().size());
+    }
 
 }

--- a/src/examples/org/tensorics/core/examples/sprint/Team.java
+++ b/src/examples/org/tensorics/core/examples/sprint/Team.java
@@ -33,7 +33,5 @@ public class Team {
             return false;
         return true;
     }
-    
-    
 
 }

--- a/src/java/org/tensorics/core/commons/operations/Conversions.java
+++ b/src/java/org/tensorics/core/commons/operations/Conversions.java
@@ -28,7 +28,7 @@ package org.tensorics.core.commons.operations;
  * @author caguiler
  */
 public final class Conversions {
-    
+
     /**
      * Returns the identity conversion.
      */

--- a/src/java/org/tensorics/core/commons/options/Environment.java
+++ b/src/java/org/tensorics/core/commons/options/Environment.java
@@ -25,8 +25,8 @@ package org.tensorics.core.commons.options;
 import org.tensorics.core.math.ExtendedField;
 
 /**
- * Encapsulates a field (on which all calculations are based) and a set of options, since the two are very commonly
- * used together and have to be passed on on many occasions.
+ * Encapsulates a field (on which all calculations are based) and a set of options, since the two are very commonly used
+ * together and have to be passed on on many occasions.
  * 
  * @author kfuchsbe
  * @param <S> The type of the scalar values (elements of the field on which the operations are based)

--- a/src/java/org/tensorics/core/commons/util/ValuePair.java
+++ b/src/java/org/tensorics/core/commons/util/ValuePair.java
@@ -43,8 +43,8 @@ public final class ValuePair<V> extends AbstractPair<V> {
      * @param rightValue the right value of the pair
      */
     private ValuePair(V leftValue, V rightValue) {
-        super(checkNotNull(leftValue, "leftValue must not be null"), checkNotNull(rightValue,
-                "rightValue must not be null"));
+        super(checkNotNull(leftValue, "leftValue must not be null"),
+                checkNotNull(rightValue, "rightValue must not be null"));
     }
 
     public static <V> ValuePair<V> fromLeftRight(V leftValue, V rightValue) {

--- a/src/java/org/tensorics/core/expressions/BinaryOperationExpression.java
+++ b/src/java/org/tensorics/core/expressions/BinaryOperationExpression.java
@@ -55,7 +55,7 @@ public class BinaryOperationExpression<T> extends AbstractDeferredExpression<T> 
     public BinaryOperation<T> getOperation() {
         return operation;
     }
- 
+
     public Expression<T> getLeft() {
         return left;
     }

--- a/src/java/org/tensorics/core/expressions/BinaryPredicateExpression.java
+++ b/src/java/org/tensorics/core/expressions/BinaryPredicateExpression.java
@@ -64,6 +64,6 @@ public class BinaryPredicateExpression<T> extends AbstractDeferredExpression<Boo
 
     @Override
     public List<Node> getChildren() {
-        return ImmutableList.<Node>of(left, right);
+        return ImmutableList.<Node> of(left, right);
     }
 }

--- a/src/java/org/tensorics/core/expressions/WindowedExpression.java
+++ b/src/java/org/tensorics/core/expressions/WindowedExpression.java
@@ -12,9 +12,9 @@ import org.tensorics.core.tree.domain.AbstractDeferredExpression;
 import org.tensorics.core.tree.domain.Expression;
 
 /**
- * Expression that evaluates the targetExpression given the result of the enabling expression. The enabling
- * expression is an {@link Expression} of {@link Boolean} that decides if the targetExpression is
- * resolved or not. This expression resolves into an {@link EvaluationStatus}.
+ * Expression that evaluates the targetExpression given the result of the enabling expression. The enabling expression
+ * is an {@link Expression} of {@link Boolean} that decides if the targetExpression is resolved or not. This expression
+ * resolves into an {@link EvaluationStatus}.
  * 
  * @see WindowedExpressionResolver
  * @param T the type of the target expression

--- a/src/java/org/tensorics/core/function/MapBackedDiscreteFunction.java
+++ b/src/java/org/tensorics/core/function/MapBackedDiscreteFunction.java
@@ -90,8 +90,6 @@ public class MapBackedDiscreteFunction<X, Y> implements DiscreteFunction<X, Y>, 
         }
         return true;
     }
-    
-    
 
     @Override
     public String toString() {

--- a/src/java/org/tensorics/core/function/interpolation/LinearInterpolationStrategy.java
+++ b/src/java/org/tensorics/core/function/interpolation/LinearInterpolationStrategy.java
@@ -18,7 +18,7 @@ import com.google.common.base.Preconditions;
  * @see InterpolationStrategy
  * @author agorzaws, caguiler
  */
-public class LinearInterpolationStrategy<Y> extends ScalarSupport<Y> implements InterpolationStrategy<Y> {
+public class LinearInterpolationStrategy<Y> extends ScalarSupport<Y>implements InterpolationStrategy<Y> {
 
     private static final long serialVersionUID = 1L;
 

--- a/src/java/org/tensorics/core/function/lang/FunctionSupport.java
+++ b/src/java/org/tensorics/core/function/lang/FunctionSupport.java
@@ -46,8 +46,8 @@ public class FunctionSupport<Y> extends FunctionSupportWithConversionAndComparat
      * @param conversion defines how to transform a value of X type to Y type
      * @return a {@link FunctionSupportWithConversionAndComparator} with a given {@link Conversion} set
      */
-    public final <X> FunctionSupportWithConversionAndComparator<X, Y> withConversionAndComparator(Conversion<X, Y> conversion,
-            Comparator<X> comparator) {
+    public final <X> FunctionSupportWithConversionAndComparator<X, Y> withConversionAndComparator(
+            Conversion<X, Y> conversion, Comparator<X> comparator) {
         return new FunctionSupportWithConversionAndComparator<>(environment(), conversion, comparator);
     }
 }

--- a/src/java/org/tensorics/core/function/lang/FunctionSupportWithConversionAndComparator.java
+++ b/src/java/org/tensorics/core/function/lang/FunctionSupportWithConversionAndComparator.java
@@ -51,7 +51,8 @@ public class FunctionSupportWithConversionAndComparator<X, Y> extends ScalarIter
      * @param environment the {@link Environment} for this support
      * @param conversion defines how to transform a value of X type to Y type
      */
-    FunctionSupportWithConversionAndComparator(Environment<Y> environment, Conversion<X, Y> conversion, Comparator<X> comparator) {
+    FunctionSupportWithConversionAndComparator(Environment<Y> environment, Conversion<X, Y> conversion,
+            Comparator<X> comparator) {
         super(environment.field());
         this.environment = environment;
         this.conversion = conversion;

--- a/src/java/org/tensorics/core/function/operations/CodomainExtraction.java
+++ b/src/java/org/tensorics/core/function/operations/CodomainExtraction.java
@@ -28,7 +28,8 @@ import org.tensorics.core.function.DiscreteFunction;
 import com.google.common.base.Preconditions;
 
 /**
- * A conversion that takes a {@link DiscreteFunction} and produces an iterable that contains the values of its codomain. See <a href="https://en.wikipedia.org/wiki/Codomain">Codomain</a>
+ * A conversion that takes a {@link DiscreteFunction} and produces an iterable that contains the values of its codomain.
+ * See <a href="https://en.wikipedia.org/wiki/Codomain">Codomain</a>
  *
  * @param <Y> the type of the dependent variable (output)of the discrete function
  * @author caguiler

--- a/src/java/org/tensorics/core/function/operations/DiscreteFunctionAddition.java
+++ b/src/java/org/tensorics/core/function/operations/DiscreteFunctionAddition.java
@@ -34,8 +34,7 @@ import org.tensorics.core.function.DiscreteFunction;
  * @param <X> the type of the independent variable in the {@link DiscreteFunction}.
  * @param <Y> the type of the dependent variable in the {@link DiscreteFunction}
  */
-public class DiscreteFunctionAddition<X, Y>
-        extends AbstractDiscreteFunctionBinaryOperation<X, Y> {
+public class DiscreteFunctionAddition<X, Y> extends AbstractDiscreteFunctionBinaryOperation<X, Y> {
 
     DiscreteFunctionAddition(Environment<Y> environment, Conversion<X, Y> conversion, Comparator<X> comparator) {
         super(environment, conversion, environment.field().addition(), comparator);

--- a/src/java/org/tensorics/core/function/operations/DiscreteFunctionDivision.java
+++ b/src/java/org/tensorics/core/function/operations/DiscreteFunctionDivision.java
@@ -34,8 +34,7 @@ import org.tensorics.core.function.DiscreteFunction;
  * @param <X> the type of the independent variable in the {@link DiscreteFunction}.
  * @param <Y> the type of the dependent variable in the {@link DiscreteFunction}
  */
-public class DiscreteFunctionDivision<X, Y>
-        extends AbstractDiscreteFunctionBinaryOperation<X, Y> {
+public class DiscreteFunctionDivision<X, Y> extends AbstractDiscreteFunctionBinaryOperation<X, Y> {
 
     DiscreteFunctionDivision(Environment<Y> environment, Conversion<X, Y> conversion, Comparator<X> comparator) {
         super(environment, conversion, environment.field().division(), comparator);

--- a/src/java/org/tensorics/core/function/operations/DiscreteFunctionMultiplication.java
+++ b/src/java/org/tensorics/core/function/operations/DiscreteFunctionMultiplication.java
@@ -28,14 +28,14 @@ import org.tensorics.core.commons.options.Environment;
 import org.tensorics.core.function.DiscreteFunction;
 
 /**
- * The {@link AbstractDiscreteFunctionBinaryOperation} that describes the multiplication of two {@link DiscreteFunction}s
+ * The {@link AbstractDiscreteFunctionBinaryOperation} that describes the multiplication of two {@link DiscreteFunction}
+ * s
  * 
  * @author caguiler
  * @param <X> the type of the independent variable in the {@link DiscreteFunction}.
  * @param <Y> the type of the dependent variable in the {@link DiscreteFunction}
  */
-public class DiscreteFunctionMultiplication<X, Y>
-        extends AbstractDiscreteFunctionBinaryOperation<X, Y> {
+public class DiscreteFunctionMultiplication<X, Y> extends AbstractDiscreteFunctionBinaryOperation<X, Y> {
 
     DiscreteFunctionMultiplication(Environment<Y> environment, Conversion<X, Y> conversion, Comparator<X> comparator) {
         super(environment, conversion, environment.field().multiplication(), comparator);

--- a/src/java/org/tensorics/core/function/operations/DiscreteFunctionSubtraction.java
+++ b/src/java/org/tensorics/core/function/operations/DiscreteFunctionSubtraction.java
@@ -34,8 +34,7 @@ import org.tensorics.core.function.DiscreteFunction;
  * @param <X> the type of the independent variable in the {@link DiscreteFunction}.
  * @param <Y> the type of the dependent variable in the {@link DiscreteFunction}
  */
-public class DiscreteFunctionSubtraction<X, Y>
-        extends AbstractDiscreteFunctionBinaryOperation<X, Y> {
+public class DiscreteFunctionSubtraction<X, Y> extends AbstractDiscreteFunctionBinaryOperation<X, Y> {
 
     DiscreteFunctionSubtraction(Environment<Y> environment, Conversion<X, Y> conversion, Comparator<X> comparator) {
         super(environment, conversion, environment.field().subtraction(), comparator);

--- a/src/java/org/tensorics/core/functional/Func1.java
+++ b/src/java/org/tensorics/core/functional/Func1.java
@@ -12,7 +12,7 @@ package org.tensorics.core.functional;
  */
 @FunctionalInterface
 public interface Func1<T, R> extends FiniteArgumentFunction<R> {
-    
+
     R apply(T t);
 
     @Override

--- a/src/java/org/tensorics/core/iterable/expressions/BinaryPredicateIterableExpression.java
+++ b/src/java/org/tensorics/core/iterable/expressions/BinaryPredicateIterableExpression.java
@@ -30,7 +30,6 @@ import org.tensorics.core.tree.domain.Node;
 
 import com.google.common.collect.ImmutableList;
 
-
 /**
  * An unresolved expression which can be resolved by applying a binary predicate on the results of the two operands
  * (left, right). Any instance contains the binary predicate itself as well as expressions for both operands.
@@ -44,7 +43,8 @@ public class BinaryPredicateIterableExpression<T> extends AbstractDeferredExpres
     private final Expression<Iterable<T>> left;
     private final Expression<T> right;
 
-    public BinaryPredicateIterableExpression(BinaryPredicate<T> predicate, Expression<Iterable<T>> left, Expression<T> right) {
+    public BinaryPredicateIterableExpression(BinaryPredicate<T> predicate, Expression<Iterable<T>> left,
+            Expression<T> right) {
         super();
         this.predicate = checkNotNull(predicate, "Predicate must not be null!");
         this.left = checkNotNull(left, "Left operand must not be null!");

--- a/src/java/org/tensorics/core/iterable/lang/ScalarIterableSupport.java
+++ b/src/java/org/tensorics/core/iterable/lang/ScalarIterableSupport.java
@@ -59,11 +59,11 @@ public class ScalarIterableSupport<V> extends ScalarSupport<V> {
     public V sumOfSquaresOf(Iterable<V> values) {
         return repository.sumOfSquares().apply(values);
     }
-    
+
     public V varOf(Iterable<V> values) {
         return repository.var().apply(values);
     }
-    
+
     public V stdOf(Iterable<V> values) {
         return repository.std().apply(values);
     }

--- a/src/java/org/tensorics/core/iterable/operations/IterableAverage.java
+++ b/src/java/org/tensorics/core/iterable/operations/IterableAverage.java
@@ -33,7 +33,7 @@ import org.tensorics.core.scalar.lang.ScalarSupport;
  * @author kfuchsbe
  * @param <V> the type of the scalar values over which to average.
  */
-public class IterableAverage<V> extends ScalarSupport<V> implements IterableOperation<V> {
+public class IterableAverage<V> extends ScalarSupport<V>implements IterableOperation<V> {
 
     private final IterableSize<V> size;
     private final IterableSum<V> sum;

--- a/src/java/org/tensorics/core/iterable/operations/IterableRms.java
+++ b/src/java/org/tensorics/core/iterable/operations/IterableRms.java
@@ -31,13 +31,13 @@ import org.tensorics.core.scalar.lang.ScalarSupport;
  * An operation that takes and iterable of a certain type of values (for which a field has to be provided) and
  * calculates the rms (Root mean square) out of it.
  * <p>
- * For the definition of the root mean square, have a look at <a
- * href="http://en.wikipedia.org/wiki/Root_mean_square">wikipedia</a>.
+ * For the definition of the root mean square, have a look at
+ * <a href="http://en.wikipedia.org/wiki/Root_mean_square">wikipedia</a>.
  * 
  * @author kfuchsbe
  * @param <V> the type of the scalars (elements of the field on which the rms will be based)
  */
-public class IterableRms<V> extends ScalarSupport<V> implements IterableOperation<V> {
+public class IterableRms<V> extends ScalarSupport<V>implements IterableOperation<V> {
 
     private final IterableSumOfSquares<V> sumOfSquares;
     private final IterableSize<V> size;

--- a/src/java/org/tensorics/core/iterable/operations/IterableSize.java
+++ b/src/java/org/tensorics/core/iterable/operations/IterableSize.java
@@ -31,7 +31,7 @@ import org.tensorics.core.scalar.lang.ScalarSupport;
  * @author kfuchsbe
  * @param <V> the type of the elements of the field.
  */
-public class IterableSize<V> extends ScalarSupport<V> implements IterableOperation<V> {
+public class IterableSize<V> extends ScalarSupport<V>implements IterableOperation<V> {
 
     public IterableSize(ExtendedField<V> field) {
         super(field);

--- a/src/java/org/tensorics/core/iterable/operations/IterableStd.java
+++ b/src/java/org/tensorics/core/iterable/operations/IterableStd.java
@@ -19,7 +19,7 @@ import org.tensorics.core.scalar.lang.ScalarSupport;
  * @author caguiler
  * @param <V> the type of the scalars (elements of the field on which the standard deviation will be based)
  */
-public class IterableStd<V> extends ScalarSupport<V> implements IterableOperation<V> {
+public class IterableStd<V> extends ScalarSupport<V>implements IterableOperation<V> {
 
     private final IterableVar<V> iterableVar;
     private final ExtendedField<V> field;

--- a/src/java/org/tensorics/core/iterable/operations/IterableSum.java
+++ b/src/java/org/tensorics/core/iterable/operations/IterableSum.java
@@ -31,7 +31,7 @@ import org.tensorics.core.scalar.lang.ScalarSupport;
  * @author kfuchsbe
  * @param <V> the type of the elements of the field on which the operation is based on.
  */
-public class IterableSum<V> extends ScalarSupport<V> implements IterableOperation<V> {
+public class IterableSum<V> extends ScalarSupport<V>implements IterableOperation<V> {
 
     public IterableSum(ExtendedField<V> field) {
         super(field);

--- a/src/java/org/tensorics/core/iterable/operations/IterableSumOfSquares.java
+++ b/src/java/org/tensorics/core/iterable/operations/IterableSumOfSquares.java
@@ -31,7 +31,7 @@ import org.tensorics.core.scalar.lang.ScalarSupport;
  * @author kfuchsbe
  * @param <V> the type of the elements of the field.
  */
-public class IterableSumOfSquares<V> extends ScalarSupport<V> implements IterableOperation<V> {
+public class IterableSumOfSquares<V> extends ScalarSupport<V>implements IterableOperation<V> {
 
     public IterableSumOfSquares(ExtendedField<V> field) {
         super(field);

--- a/src/java/org/tensorics/core/iterable/operations/IterableVar.java
+++ b/src/java/org/tensorics/core/iterable/operations/IterableVar.java
@@ -21,7 +21,7 @@ import org.tensorics.core.scalar.lang.ScalarSupport;
  * @author caguiler
  * @param <V> the type of the scalars (elements of the field on which the variance will be based)
  */
-public class IterableVar<V> extends ScalarSupport<V> implements IterableOperation<V> {
+public class IterableVar<V> extends ScalarSupport<V>implements IterableOperation<V> {
 
     private final IterableAverage<V> iterableAverage;
     private final ExtendedField<V> field;

--- a/src/java/org/tensorics/core/lang/DoubleTensorics.java
+++ b/src/java/org/tensorics/core/lang/DoubleTensorics.java
@@ -57,9 +57,9 @@ import org.tensorics.core.tree.domain.Expression;
 import org.tensorics.core.units.Unit;
 
 /**
- * Provides delegate methods to a static instance of a {@code TensoricSupport<Double>}. This is for convenience purposes, so
- * that a simple calculation does not have to inherit from the support class, but can statically import methods from
- * this class.
+ * Provides delegate methods to a static instance of a {@code TensoricSupport<Double>}. This is for convenience
+ * purposes, so that a simple calculation does not have to inherit from the support class, but can statically import
+ * methods from this class.
  * 
  * @author kfuchsbe
  */

--- a/src/java/org/tensorics/core/lang/EnvironmentImpl.java
+++ b/src/java/org/tensorics/core/lang/EnvironmentImpl.java
@@ -84,5 +84,4 @@ public final class EnvironmentImpl<V> implements QuantityEnvironment<V> {
         return new EnvironmentImpl<>(extendedField, optionRegistry.with(newOption));
     }
 
-
 }

--- a/src/java/org/tensorics/core/lang/ManipulationOptions.java
+++ b/src/java/org/tensorics/core/lang/ManipulationOptions.java
@@ -75,7 +75,7 @@ public final class ManipulationOptions {
                 new RequireBothValidStrategy(), //
                 new UncorrelatedErrorPropagationStrategy<>(field), //
                 new JScienceQuantificationStrategy<>(field.cheating()), //
-                new LeftContextPreservedStrategy(), 
+                new LeftContextPreservedStrategy(),
                 new ImmutableConfidenceLevel<>(field.cheating().fromDouble(DEFAULT_CONFIDENCE_LEVEL)),
                 new LinearInterpolationStrategy<>(field)));
     }

--- a/src/java/org/tensorics/core/lang/TensoricScript.java
+++ b/src/java/org/tensorics/core/lang/TensoricScript.java
@@ -43,7 +43,7 @@ import org.tensorics.core.tree.domain.Node;
  * @param <E> the type of the elements of the field on which all the calculations are based on.
  * @param <T> the type which shall be returned by the script, after it is executed (resolved)
  */
-public abstract class TensoricScript<E, T> extends TensoricExpressionSupport<E> implements Expression<T> {
+public abstract class TensoricScript<E, T> extends TensoricExpressionSupport<E>implements Expression<T> {
 
     private static final boolean RESOLVED = false;
     private final Expression<T> internalExpression;

--- a/src/java/org/tensorics/core/lang/TensoricTask.java
+++ b/src/java/org/tensorics/core/lang/TensoricTask.java
@@ -33,7 +33,7 @@ import java.util.concurrent.Callable;
  * @param <E> the type of the elements of the tensors
  * @param <T> the type of the result of the script.
  */
-public abstract class TensoricTask<E, T> extends TensoricSupport<E> implements Callable<T> {
+public abstract class TensoricTask<E, T> extends TensoricSupport<E>implements Callable<T> {
 
     public TensoricTask(EnvironmentImpl<E> environment) {
         super(environment);

--- a/src/java/org/tensorics/core/lang/Tensorics.java
+++ b/src/java/org/tensorics/core/lang/Tensorics.java
@@ -2,7 +2,7 @@
  /*******************************************************************************
  *
  * This file is part of tensorics.
- * 
+ *
  * Copyright (c) 2008-2011, CERN. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  ******************************************************************************/
 // @formatter:on
 
@@ -35,6 +35,7 @@ import org.tensorics.core.quantity.QuantifiedValue;
 import org.tensorics.core.tensor.ImmutableScalar;
 import org.tensorics.core.tensor.ImmutableTensor;
 import org.tensorics.core.tensor.Position;
+import org.tensorics.core.tensor.Scalar;
 import org.tensorics.core.tensor.Shape;
 import org.tensorics.core.tensor.Tensor;
 import org.tensorics.core.tensor.TensorBuilder;
@@ -58,389 +59,380 @@ import org.tensorics.core.units.Unit;
 import com.google.common.base.Optional;
 
 /**
- * The main entry point for constructing and structural manipulation of
- * tensorics. If mathematical operations are required, then you should either
- * inherit from {@link TensoricSupport} (or one of its convenience
- * implementations) or use the {@link #using(ExtendedField)} method (only
- * recommended for one-liners).
+ * The main entry point for constructing and structural manipulation of tensorics. If mathematical operations are
+ * required, then you should either inherit from {@link TensoricSupport} (or one of its convenience implementations) or
+ * use the {@link #using(ExtendedField)} method (only recommended for one-liners).
  * <p>
- * Additional utilities for supporting classes can be found in the corresponding
- * utility classes. E.g.
+ * Additional utilities for supporting classes can be found in the corresponding utility classes. E.g.
  * <ul>
  * <li>{@link org.tensorics.core.tensor.Positions}
  * <li>{@link org.tensorics.core.tensor.Shapes}
  * <li>{@link QuantityTensors}
  * <li>{@link Tensorbackeds}
  * </ul>
- * 
+ *
  * @author kfuchsbe, agorzaws, mihostet
  */
 public final class Tensorics {
 
-	/**
-	 * private constructor to avoid instantiation
-	 */
-	private Tensorics() {
-		/* only static methods */
-	}
+    /**
+     * private constructor to avoid instantiation
+     */
+    private Tensorics() {
+        /* only static methods */
+    }
 
-	/**
-	 * Creates an instance of a 'support' type class, which provides methods as
-	 * starting points for the 'fluent' API for tensor manipulation.
-	 * 
-	 * @param field
-	 *            the (mathematical construct) field which defines the
-	 *            operations for the tensor elements.
-	 * @return a tensoric support, which provides the starting methods for the
-	 *         tensoric fluent API.
-	 * @param <E>
-	 *            the types of values in the field
-	 */
-	public static <E> TensoricSupport<E> using(ExtendedField<E> field) {
-		return new TensoricSupport<>(EnvironmentImpl.of(field, ManipulationOptions.defaultOptions(field)));
-	}
+    /**
+     * Creates an instance of a 'support' type class, which provides methods as starting points for the 'fluent' API for
+     * tensor manipulation.
+     *
+     * @param field the (mathematical construct) field which defines the operations for the tensor elements.
+     * @return a tensoric support, which provides the starting methods for the tensoric fluent API.
+     * @param <E> the types of values in the field
+     */
+    public static <E> TensoricSupport<E> using(ExtendedField<E> field) {
+        return new TensoricSupport<>(EnvironmentImpl.of(field, ManipulationOptions.defaultOptions(field)));
+    }
 
-	public static <E> Tensor<E> merge(Iterable<Tensor<E>> tensors) {
-		return TensorStructurals.merge(tensors);
-	}
+    public static <E> Tensor<E> merge(Iterable<Tensor<E>> tensors) {
+        return TensorStructurals.merge(tensors);
+    }
 
-	/**
-	 * @see TensorStructurals#mergeContextIntoShape(Tensor)
-	 */
-	public static <E> Tensor<E> mergeContextIntoShape(Tensor<E> tensor) {
-		return TensorStructurals.mergeContextIntoShape(tensor);
-	}
+    /**
+     * @see TensorStructurals#mergeContextIntoShape(Tensor)
+     */
+    public static <E> Tensor<E> mergeContextIntoShape(Tensor<E> tensor) {
+        return TensorStructurals.mergeContextIntoShape(tensor);
+    }
 
-	/**
-	 * @see ImmutableTensor#builder(Set)
-	 */
-	public static <T> TensorBuilder<T> builder(Set<Class<?>> dimensions) {
-		return ImmutableTensor.builder(dimensions);
-	}
+    /**
+     * @see ImmutableTensor#builder(Set)
+     */
+    public static <T> TensorBuilder<T> builder(Set<Class<?>> dimensions) {
+        return ImmutableTensor.builder(dimensions);
+    }
 
-	/**
-	 * @see ImmutableTensor#builder(Class...)
-	 */
-	public static <T> TensorBuilder<T> builder(Class<?>... dimensions) {
-		return ImmutableTensor.builder(dimensions);
-	}
+    /**
+     * @see ImmutableTensor#builder(Class...)
+     */
+    public static <T> TensorBuilder<T> builder(Class<?>... dimensions) {
+        return ImmutableTensor.builder(dimensions);
+    }
 
-	/**
-	 * @see ImmutableTensor#fromMap(Set, Map)
-	 */
-	public static <T> Tensor<T> fromMap(Set<Class<?>> dimensions, Map<Position, T> map) {
-		return ImmutableTensor.fromMap(dimensions, map);
-	}
+    /**
+     * @see ImmutableTensor#fromMap(Set, Map)
+     */
+    public static <T> Tensor<T> fromMap(Set<Class<?>> dimensions, Map<Position, T> map) {
+        return ImmutableTensor.fromMap(dimensions, map);
+    }
 
-	/**
-	 * @see ImmutableTensor#copyOf(Tensor)
-	 */
-	public static <T> Tensor<T> copyOf(Tensor<T> tensor) {
-		return ImmutableTensor.copyOf(tensor);
-	}
+    /**
+     * @see ImmutableTensor#copyOf(Tensor)
+     */
+    public static <T> Tensor<T> copyOf(Tensor<T> tensor) {
+        return ImmutableTensor.copyOf(tensor);
+    }
 
-	/**
-	 * @see ImmutableTensor#builderFrom(Tensor)
-	 */
-	public static <T> TensorBuilder<T> builderFrom(Tensor<T> tensor) {
-		return ImmutableTensor.builderFrom(tensor);
-	}
+    /**
+     * @see ImmutableTensor#builderFrom(Tensor)
+     */
+    public static <T> TensorBuilder<T> builderFrom(Tensor<T> tensor) {
+        return ImmutableTensor.builderFrom(tensor);
+    }
 
-	/**
-	 * @see ImmutableTensor#zeroDimensionalOf(Object)
-	 * @deprecated use {@link #scalarOf(Object)}
-	 */
-	@Deprecated
-	public static <T> Tensor<T> zeroDimensionalOf(T value) {
-		return ImmutableTensor.zeroDimensionalOf(value);
-	}
-	
-	/**
-	 * @see ImmutableScalar#of(Object)
-	 */
-	public static <T> ImmutableScalar<T> scalarOf(T value) {
-		return ImmutableScalar.of(value);
-	}
+    /**
+     * @see ImmutableTensor#zeroDimensionalOf(Object)
+     * @deprecated use {@link #scalarOf(Object)}
+     */
+    @Deprecated
+    public static <T> Tensor<T> zeroDimensionalOf(T value) {
+        return ImmutableTensor.zeroDimensionalOf(value);
+    }
 
-	/**
-	 * @see ImmutableQuantifiedValue#of(Object, Unit)
-	 */
-	public static <V> ImmutableQuantifiedValue<V> quantityOf(V value, Unit unit) {
-		return ImmutableQuantifiedValue.of(value, unit);
-	}
+    /**
+     * @see ImmutableScalar#of(Object)
+     */
+    public static <T> ImmutableScalar<T> scalarOf(T value) {
+        return ImmutableScalar.of(value);
+    }
 
-	/**
-	 * Convenience method to create a quantity directly from a jscience unit.
-	 * 
-	 * @param value
-	 *            the of the quantity
-	 * @param unit
-	 *            the unit of the quantity
-	 * @return a new instance of the quantity
-	 * @see Tensorics#quantityOf(Object, Unit)
-	 */
-	public static <V> ImmutableQuantifiedValue<V> quantityOf(V value, javax.measure.unit.Unit<?> unit) {
-		return quantityOf(value, JScienceUnit.of(unit));
-	}
+    /**
+     * @see ImmutableQuantifiedValue#of(Object, Unit)
+     */
+    public static <V> ImmutableQuantifiedValue<V> quantityOf(V value, Unit unit) {
+        return ImmutableQuantifiedValue.of(value, unit);
+    }
 
-	/**
-	 * @see Tensorbackeds#builderFor(Class)
-	 */
-	public static <V, TB extends Tensorbacked<V>> TensorbackedBuilder<V, TB> builderFor(Class<TB> tensorbackedClass) {
-		return Tensorbackeds.builderFor(tensorbackedClass);
-	}
+    /**
+     * Convenience method to create a quantity directly from a jscience unit.
+     *
+     * @param value the of the quantity
+     * @param unit the unit of the quantity
+     * @return a new instance of the quantity
+     * @see Tensorics#quantityOf(Object, Unit)
+     */
+    public static <V> ImmutableQuantifiedValue<V> quantityOf(V value, javax.measure.unit.Unit<?> unit) {
+        return quantityOf(value, JScienceUnit.of(unit));
+    }
 
-	/**
-	 * @see Tensorbackeds#sizeOf(Tensorbacked)
-	 */
-	public static <TB extends Tensorbacked<?>> int sizeOf(TB tensorbacked) {
-		return Tensorbackeds.sizeOf(tensorbacked);
-	}
+    /**
+     * @see Tensorbackeds#builderFor(Class)
+     */
+    public static <V, TB extends Tensorbacked<V>> TensorbackedBuilder<V, TB> builderFor(Class<TB> tensorbackedClass) {
+        return Tensorbackeds.builderFor(tensorbackedClass);
+    }
 
-	/**
-	 * @see Tensorbackeds#dimensionalityOf(Tensorbacked)
-	 */
-	public static <TB extends Tensorbacked<?>> int dimensionalityOf(TB tensorbacked) {
-		return Tensorbackeds.dimensionalityOf(tensorbacked);
-	}
+    /**
+     * @see Tensorbackeds#sizeOf(Tensorbacked)
+     */
+    public static <TB extends Tensorbacked<?>> int sizeOf(TB tensorbacked) {
+        return Tensorbackeds.sizeOf(tensorbacked);
+    }
 
-	/**
-	 * @see Tensorbackeds#empty(Class)
-	 */
-	public static <V, TB extends Tensorbacked<V>> TB empty(Class<TB> tensorbackedClass) {
-		return Tensorbackeds.empty(tensorbackedClass);
-	}
+    /**
+     * @see Tensorbackeds#dimensionalityOf(Tensorbacked)
+     */
+    public static <TB extends Tensorbacked<?>> int dimensionalityOf(TB tensorbacked) {
+        return Tensorbackeds.dimensionalityOf(tensorbacked);
+    }
 
-	/**
-	 * @see Tensorbackeds#validitiesOf(Tensorbacked)
-	 */
-	public static <S> Tensor<Boolean> validitiesOf(Tensorbacked<QuantifiedValue<S>> tensorbacked) {
-		return Tensorbackeds.validitiesOf(tensorbacked);
-	}
+    /**
+     * @see Tensorbackeds#empty(Class)
+     */
+    public static <V, TB extends Tensorbacked<V>> TB empty(Class<TB> tensorbackedClass) {
+        return Tensorbackeds.empty(tensorbackedClass);
+    }
 
-	/**
-	 * @see Tensorbackeds#valuesOf(Tensorbacked)
-	 */
-	public static <S> Tensor<S> valuesOf(Tensorbacked<QuantifiedValue<S>> tensorbacked) {
-		return Tensorbackeds.valuesOf(tensorbacked);
-	}
+    /**
+     * @see Tensorbackeds#validitiesOf(Tensorbacked)
+     */
+    public static <S> Tensor<Boolean> validitiesOf(Tensorbacked<QuantifiedValue<S>> tensorbacked) {
+        return Tensorbackeds.validitiesOf(tensorbacked);
+    }
 
-	/**
-	 * @see Tensorbackeds#errorsOf(Tensorbacked)
-	 */
-	public static <S> Tensor<Optional<S>> errorsOf(Tensorbacked<QuantifiedValue<S>> tensorbacked) {
-		return Tensorbackeds.errorsOf(tensorbacked);
-	}
+    /**
+     * @see Tensorbackeds#valuesOf(Tensorbacked)
+     */
+    public static <S> Tensor<S> valuesOf(Tensorbacked<QuantifiedValue<S>> tensorbacked) {
+        return Tensorbackeds.valuesOf(tensorbacked);
+    }
 
-	/**
-	 * @see Tensorbackeds#positionsOf(Tensorbacked)
-	 */
-	public static Set<Position> positionsOf(Tensorbacked<?> tensorbacked) {
-		return Tensorbackeds.positionsOf(tensorbacked);
-	}
+    /**
+     * @see Tensorbackeds#errorsOf(Tensorbacked)
+     */
+    public static <S> Tensor<Optional<S>> errorsOf(Tensorbacked<QuantifiedValue<S>> tensorbacked) {
+        return Tensorbackeds.errorsOf(tensorbacked);
+    }
 
-	/**
-	 * @deprecated use renamed method {@link #quantityTensorOf(Tensor, Unit)}
-	 */
-	@Deprecated
-	public static <S> Tensor<QuantifiedValue<S>> convertToQuantified(Tensor<S> tensor, Unit unit) {
-		return QuantityTensors.quantityTensorOf(tensor, unit);
-	}
+    /**
+     * @see Tensorbackeds#positionsOf(Tensorbacked)
+     */
+    public static Set<Position> positionsOf(Tensorbacked<?> tensorbacked) {
+        return Tensorbackeds.positionsOf(tensorbacked);
+    }
 
-	/**
-	 * @see QuantityTensors#quantityTensorOf(Tensor, Unit)
-	 */
-	public static <S> Tensor<QuantifiedValue<S>> quantityTensorOf(Tensor<S> tensor, Unit unit) {
-		return QuantityTensors.quantityTensorOf(tensor, unit);
-	}
+    /**
+     * @deprecated use renamed method {@link #quantityTensorOf(Tensor, Unit)}
+     */
+    @Deprecated
+    public static <S> Tensor<QuantifiedValue<S>> convertToQuantified(Tensor<S> tensor, Unit unit) {
+        return QuantityTensors.quantityTensorOf(tensor, unit);
+    }
 
-	/**
-	 * @see QuantityTensors#unitOf(Tensor)
-	 */
-	public static <S> Unit unitOf(Tensor<QuantifiedValue<S>> tensor) {
-		return QuantityTensors.unitOf(tensor);
-	}
+    /**
+     * @see QuantityTensors#quantityTensorOf(Tensor, Unit)
+     */
+    public static <S> Tensor<QuantifiedValue<S>> quantityTensorOf(Tensor<S> tensor, Unit unit) {
+        return QuantityTensors.quantityTensorOf(tensor, unit);
+    }
 
-	/**
-	 * @see Tensorbackeds#unitOf(Tensorbacked)
-	 */
-	public static <S> Unit unitOf(Tensorbacked<QuantifiedValue<S>> tensorbacked) {
-		return Tensorbackeds.unitOf(tensorbacked);
-	}
+    /**
+     * @see QuantityTensors#unitOf(Tensor)
+     */
+    public static <S> Unit unitOf(Tensor<QuantifiedValue<S>> tensor) {
+        return QuantityTensors.unitOf(tensor);
+    }
 
-	/**
-	 * @see Tensorbackeds#shapeOf(Tensorbacked)
-	 */
-	public static Shape shapeOf(Tensorbacked<?> tensorbacked) {
-		return Tensorbackeds.shapeOf(tensorbacked);
-	}
+    /**
+     * @see Tensorbackeds#unitOf(Tensorbacked)
+     */
+    public static <S> Unit unitOf(Tensorbacked<QuantifiedValue<S>> tensorbacked) {
+        return Tensorbackeds.unitOf(tensorbacked);
+    }
 
-	public static Set<Class<?>> dimensionsOf(Tensorbacked<?> tensorbacked) {
-		return Tensorbackeds.shapeOf(tensorbacked).dimensionSet();
-	}
+    /**
+     * @see Tensorbackeds#shapeOf(Tensorbacked)
+     */
+    public static Shape shapeOf(Tensorbacked<?> tensorbacked) {
+        return Tensorbackeds.shapeOf(tensorbacked);
+    }
 
-	/**
-	 * @see TensorStructurals#from(Tensor)
-	 */
-	public static <V> OngoingTensorManipulation<V> from(Tensor<V> tensor) {
-		return TensorStructurals.from(tensor);
-	}
+    public static Set<Class<?>> dimensionsOf(Tensorbacked<?> tensorbacked) {
+        return Tensorbackeds.shapeOf(tensorbacked).dimensionSet();
+    }
 
-	public static <V> OngoingTensorManipulation<V> from(Tensorbacked<V> tensorbacked) {
-		return TensorStructurals.from(tensorbacked.tensor());
-	}
+    /**
+     * @see TensorStructurals#from(Tensor)
+     */
+    public static <V> OngoingTensorManipulation<V> from(Tensor<V> tensor) {
+        return TensorStructurals.from(tensor);
+    }
 
-	public static Set<Class<?>> dimensionsOf(Tensor<?> tensor) {
-		return tensor.shape().dimensionSet();
-	}
+    public static <V> OngoingTensorManipulation<V> from(Tensorbacked<V> tensorbacked) {
+        return TensorStructurals.from(tensorbacked.tensor());
+    }
 
-	public static Set<Position> positionsOf(Tensor<?> tensor) {
-		return tensor.shape().positionSet();
-	}
+    public static Set<Class<?>> dimensionsOf(Tensor<?> tensor) {
+        return tensor.shape().dimensionSet();
+    }
 
-	public static <S> Tensor<Boolean> validitiesOf(Tensor<QuantifiedValue<S>> tensor) {
-		return QuantityTensors.validitiesOf(tensor);
-	}
+    public static Set<Position> positionsOf(Tensor<?> tensor) {
+        return tensor.shape().positionSet();
+    }
 
-	public static <S> Tensor<S> valuesOf(Tensor<QuantifiedValue<S>> tensor) {
-		return QuantityTensors.valuesOf(tensor);
-	}
+    public static <S> Tensor<Boolean> validitiesOf(Tensor<QuantifiedValue<S>> tensor) {
+        return QuantityTensors.validitiesOf(tensor);
+    }
 
-	public static <S> Tensor<Optional<S>> errorsOf(Tensor<QuantifiedValue<S>> tensor) {
-		return QuantityTensors.errorsOf(tensor);
-	}
+    public static <S> Tensor<S> valuesOf(Tensor<QuantifiedValue<S>> tensor) {
+        return QuantityTensors.valuesOf(tensor);
+    }
 
-	public static <S> Tensor<S> errorsOfOr(Tensor<QuantifiedValue<S>> tensor, S defaultValue) {
-		return QuantityTensors.errorsOfOr(tensor, defaultValue);
-	}
+    public static <S> Tensor<Optional<S>> errorsOf(Tensor<QuantifiedValue<S>> tensor) {
+        return QuantityTensors.errorsOf(tensor);
+    }
 
-	public static <S> OngoingFlattening<S> flatten(Tensor<S> tensor) {
-		return TensorStructurals.flatten(tensor);
-	}
+    public static <S> Tensor<S> errorsOfOr(Tensor<QuantifiedValue<S>> tensor, S defaultValue) {
+        return QuantityTensors.errorsOfOr(tensor, defaultValue);
+    }
 
-	public static <S> OngoingFlattening<S> flatten(Tensorbacked<S> tensorbacked) {
-		return Tensorbackeds.flatten(tensorbacked);
-	}
+    public static <S> OngoingFlattening<S> flatten(Tensor<S> tensor) {
+        return TensorStructurals.flatten(tensor);
+    }
 
-	public static <S> Tensor<S> sameValues(Shape shape, S value) {
-		return TensorInternals.sameValues(shape, value);
-	}
+    public static <S> OngoingFlattening<S> flatten(Tensorbacked<S> tensorbacked) {
+        return Tensorbackeds.flatten(tensorbacked);
+    }
 
-	public static <S> Tensor<S> createFrom(Shape shape, Supplier<S> supplier) {
-		return TensorInternals.createFrom(shape, supplier);
-	}
+    public static <S> Tensor<S> sameValues(Shape shape, S value) {
+        return TensorInternals.sameValues(shape, value);
+    }
 
-	public static <S> Tensor<S> createFrom(Shape shape, Function<Position, S> function) {
-		return TensorInternals.createFrom(shape, function);
-	}
+    public static <S> Tensor<S> createFrom(Shape shape, Supplier<S> supplier) {
+        return TensorInternals.createFrom(shape, supplier);
+    }
 
-	public static <S> OngoingCompletion<S> complete(Tensor<S> tensor) {
-		return TensorStructurals.complete(tensor);
-	}
+    public static <S> Tensor<S> createFrom(Shape shape, Function<Position, S> function) {
+        return TensorInternals.createFrom(shape, function);
+    }
 
-	public static <S, T> Tensor<T> transformEntries(Tensor<S> tensor, Function<Entry<Position, S>, T> function) {
-		return TensorStructurals.transformEntries(tensor, function);
-	}
+    public static <S> OngoingCompletion<S> complete(Tensor<S> tensor) {
+        return TensorStructurals.complete(tensor);
+    }
 
-	public static <S, T> Tensor<T> map(Tensor<S> tensor, Function<S, T> function) {
-		return TensorStructurals.transformScalars(tensor, function);
-	}
+    public static <S, T> Tensor<T> transformEntries(Tensor<S> tensor, Function<Entry<Position, S>, T> function) {
+        return TensorStructurals.transformEntries(tensor, function);
+    }
 
-	public static final Tensor<QuantifiedValue<Double>> zeroDimensionalOf(double value,
-			javax.measure.unit.Unit<?> unit) {
-		QuantifiedValue<Double> quantity = quantityOf(value, unit);
-		return zeroDimensionalOf(quantity);
-	}
+    public static <S, T> Tensor<T> map(Tensor<S> tensor, Function<S, T> function) {
+        return TensorStructurals.transformScalars(tensor, function);
+    }
 
-	public static final Tensor<QuantifiedValue<Double>> zeroDimensionalOf(double value, Unit unit) {
-		QuantifiedValue<Double> quantity = quantityOf(value, unit);
-		return zeroDimensionalOf(quantity);
-	}
+    public static final Scalar<QuantifiedValue<Double>> zeroDimensionalOf(double value,
+            javax.measure.unit.Unit<?> unit) {
+        QuantifiedValue<Double> quantity = quantityOf(value, unit);
+        return scalarOf(quantity);
+    }
 
-	/**
-	 * @see Tensorbackeds#tensorsOf(Iterable)
-	 */
-	public static <S> Iterable<Tensor<S>> tensorsOf(Iterable<? extends Tensorbacked<S>> tensorbackeds) {
-		return Tensorbackeds.tensorsOf(tensorbackeds);
-	}
+    public static final Scalar<QuantifiedValue<Double>> zeroDimensionalOf(double value, Unit unit) {
+        QuantifiedValue<Double> quantity = quantityOf(value, unit);
+        return scalarOf(quantity);
+    }
 
-	/**
-	 * @see Tensorbackeds#construct(Class)
-	 */
-	public static <V, TB extends Tensorbacked<V>> OngoingTensorbackedConstruction<V, TB> construct(
-			Class<TB> tensorbackedClass) {
-		return Tensorbackeds.construct(tensorbackedClass);
-	}
+    /**
+     * @see Tensorbackeds#tensorsOf(Iterable)
+     */
+    public static <S> Iterable<Tensor<S>> tensorsOf(Iterable<? extends Tensorbacked<S>> tensorbackeds) {
+        return Tensorbackeds.tensorsOf(tensorbackeds);
+    }
 
-	/**
-	 * @see Tensorbackeds#stripContext(Tensorbacked)
-	 */
-	public static <V, TB extends Tensorbacked<V>> TB stripContext(TB tensorbacked) {
-		return Tensorbackeds.stripContext(tensorbacked);
-	}
+    /**
+     * @see Tensorbackeds#construct(Class)
+     */
+    public static <V, TB extends Tensorbacked<V>> OngoingTensorbackedConstruction<V, TB> construct(
+            Class<TB> tensorbackedClass) {
+        return Tensorbackeds.construct(tensorbackedClass);
+    }
 
-	/**
-	 * @see TensorStructurals#stripContext(Tensor)
-	 */
-	public static <S> Tensor<S> stripContext(Tensor<S> tensor) {
-		return TensorStructurals.stripContext(tensor);
-	}
+    /**
+     * @see Tensorbackeds#stripContext(Tensorbacked)
+     */
+    public static <V, TB extends Tensorbacked<V>> TB stripContext(TB tensorbacked) {
+        return Tensorbackeds.stripContext(tensorbacked);
+    }
 
-	/**
-	 * @see TensorStructurals#filter(Tensor)
-	 */
-	public static <S> OngoingTensorFiltering<S> filter(Tensor<S> tensor) {
-		return TensorStructurals.filter(tensor);
-	}
+    /**
+     * @see TensorStructurals#stripContext(Tensor)
+     */
+    public static <S> Tensor<S> stripContext(Tensor<S> tensor) {
+        return TensorStructurals.stripContext(tensor);
+    }
 
-	/**
-	 * @see Tensorbackeds#filter(Tensorbacked)
-	 */
-	public static <V, TB extends Tensorbacked<V>> OngoingTensorbackedFiltering<V, TB> filter(TB tensorbacked) {
-		return Tensorbackeds.filter(tensorbacked);
-	}
+    /**
+     * @see TensorStructurals#filter(Tensor)
+     */
+    public static <S> OngoingTensorFiltering<S> filter(Tensor<S> tensor) {
+        return TensorStructurals.filter(tensor);
+    }
 
-	public static <S> Tensor<S> setContext(Tensor<S> tensor, Position context) {
-		return TensorStructurals.setContext(tensor, context);
-	}
+    /**
+     * @see Tensorbackeds#filter(Tensorbacked)
+     */
+    public static <V, TB extends Tensorbacked<V>> OngoingTensorbackedFiltering<V, TB> filter(TB tensorbacked) {
+        return Tensorbackeds.filter(tensorbacked);
+    }
 
-	public static <V, TB extends Tensorbacked<V>> TB setContext(TB tensorbacked, Position context) {
-		return Tensorbackeds.setContext(tensorbacked, context);
-	}
+    public static <S> Tensor<S> setContext(Tensor<S> tensor, Position context) {
+        return TensorStructurals.setContext(tensor, context);
+    }
 
-	/**
-	 * @see TensorStreams#tensorEntryStream(Tensor)
-	 */
-	public static <S> Stream<Map.Entry<Position, S>> stream(Tensor<S> tensor) {
-		return TensorStreams.tensorEntryStream(tensor);
-	}
+    public static <V, TB extends Tensorbacked<V>> TB setContext(TB tensorbacked, Position context) {
+        return Tensorbackeds.setContext(tensorbacked, context);
+    }
 
-	/**
-	 * @see TensorStreams#tensorEntryStream(Tensor)
-	 */
-	public static <S> Stream<Map.Entry<Position, S>> stream(Tensorbacked<S> tensorBacked) {
-		return TensorStreams.tensorEntryStream(tensorBacked.tensor());
-	}
+    /**
+     * @see TensorStreams#tensorEntryStream(Tensor)
+     */
+    public static <S> Stream<Map.Entry<Position, S>> stream(Tensor<S> tensor) {
+        return TensorStreams.tensorEntryStream(tensor);
+    }
 
-	/**
-	 * @see Tensorbackeds#shapeOf(Tensorbacked)
-	 */
-	public static <TB extends Tensorbacked<?>> Iterable<Shape> shapesOf(Iterable<TB> tensorbackeds) {
-		return Tensorbackeds.shapesOf(tensorbackeds);
-	}
+    /**
+     * @see TensorStreams#tensorEntryStream(Tensor)
+     */
+    public static <S> Stream<Map.Entry<Position, S>> stream(Tensorbacked<S> tensorBacked) {
+        return TensorStreams.tensorEntryStream(tensorBacked.tensor());
+    }
 
-	/**
-	 * @see Tensorbackeds#complete(Tensorbacked)
-	 */
-	public static <S, TB extends Tensorbacked<S>> OngoingTensorbackedCompletion<TB, S> complete(TB tensorbacked) {
-		return Tensorbackeds.complete(tensorbacked);
-	}
+    /**
+     * @see Tensorbackeds#shapeOf(Tensorbacked)
+     */
+    public static <TB extends Tensorbacked<?>> Iterable<Shape> shapesOf(Iterable<TB> tensorbackeds) {
+        return Tensorbackeds.shapesOf(tensorbackeds);
+    }
 
-	/**
-	 * @see TensorInternals#mapFrom(Tensor)
-	 */
-	public static <V> Map<Position, V> mapFrom(Tensor<V> tensor) {
-		return TensorInternals.mapFrom(tensor);
-	}
+    /**
+     * @see Tensorbackeds#complete(Tensorbacked)
+     */
+    public static <S, TB extends Tensorbacked<S>> OngoingTensorbackedCompletion<TB, S> complete(TB tensorbacked) {
+        return Tensorbackeds.complete(tensorbacked);
+    }
+
+    /**
+     * @see TensorInternals#mapFrom(Tensor)
+     */
+    public static <V> Map<Position, V> mapFrom(Tensor<V> tensor) {
+        return TensorInternals.mapFrom(tensor);
+    }
 
 }

--- a/src/java/org/tensorics/core/lang/Tensorics.java
+++ b/src/java/org/tensorics/core/lang/Tensorics.java
@@ -32,6 +32,7 @@ import java.util.stream.Stream;
 import org.tensorics.core.math.ExtendedField;
 import org.tensorics.core.quantity.ImmutableQuantifiedValue;
 import org.tensorics.core.quantity.QuantifiedValue;
+import org.tensorics.core.tensor.ImmutableScalar;
 import org.tensorics.core.tensor.ImmutableTensor;
 import org.tensorics.core.tensor.Position;
 import org.tensorics.core.tensor.Shape;
@@ -147,9 +148,18 @@ public final class Tensorics {
 
 	/**
 	 * @see ImmutableTensor#zeroDimensionalOf(Object)
+	 * @deprecated use {@link #scalarOf(Object)}
 	 */
+	@Deprecated
 	public static <T> Tensor<T> zeroDimensionalOf(T value) {
 		return ImmutableTensor.zeroDimensionalOf(value);
+	}
+	
+	/**
+	 * @see ImmutableScalar#of(Object)
+	 */
+	public static <T> ImmutableScalar<T> scalarOf(T value) {
+		return ImmutableScalar.of(value);
 	}
 
 	/**

--- a/src/java/org/tensorics/core/math/BinaryPredicates.java
+++ b/src/java/org/tensorics/core/math/BinaryPredicates.java
@@ -35,8 +35,8 @@ public final class BinaryPredicates {
 
     /**
      * Negates the given binary predicate. Thus, the {@link BinaryPredicate#test(Object, Object)} will return the
-     * logically negated value of the original. For example, if the predicate is {@code '<='}, then this method will transform
-     * the predicate {@code (a <= b) to !(a <= b)}, which is equivalent to {@code (a > b)}.
+     * logically negated value of the original. For example, if the predicate is {@code '<='}, then this method will
+     * transform the predicate {@code (a <= b) to !(a <= b)}, which is equivalent to {@code (a > b)}.
      *
      * @param original the original predicate.
      * @return
@@ -46,8 +46,8 @@ public final class BinaryPredicates {
     }
 
     /**
-     * Inverts the given binary predicate. Thus, if e.g. the predicate is {@code '<='}, then this method will transform the
-     * predicate {@code (a <= b)} to {@code (a >= b)}.
+     * Inverts the given binary predicate. Thus, if e.g. the predicate is {@code '<='}, then this method will transform
+     * the predicate {@code (a <= b)} to {@code (a >= b)}.
      *
      * @param original the original predicate.
      * @return the inverted predicate.

--- a/src/java/org/tensorics/core/math/impl/ExplicitFieldImpl.java
+++ b/src/java/org/tensorics/core/math/impl/ExplicitFieldImpl.java
@@ -95,7 +95,7 @@ public class ExplicitFieldImpl<T> implements ExplicitField<T> {
             }
         };
     }
-    
+
     @Override
     public final BinaryOperation<T> subtraction() {
         return subtractionOperation;
@@ -155,6 +155,5 @@ public class ExplicitFieldImpl<T> implements ExplicitField<T> {
     public Comparator<T> comparator() {
         return comparator;
     }
-
 
 }

--- a/src/java/org/tensorics/core/math/impl/ExtendedFieldImpl.java
+++ b/src/java/org/tensorics/core/math/impl/ExtendedFieldImpl.java
@@ -33,7 +33,7 @@ import org.tensorics.core.math.structures.ringlike.OrderedField;
  * @author kfuchsbe
  * @param <T> the type of elements of the field
  */
-public class ExtendedFieldImpl<T> extends ExplicitFieldImpl<T> implements ExtendedField<T> {
+public class ExtendedFieldImpl<T> extends ExplicitFieldImpl<T>implements ExtendedField<T> {
 
     private final org.tensorics.core.math.Math<T> math;
     private final Cheating<T> cheatingInstance;

--- a/src/java/org/tensorics/core/math/operations/BinaryFunction.java
+++ b/src/java/org/tensorics/core/math/operations/BinaryFunction.java
@@ -23,7 +23,6 @@ package org.tensorics.core.math.operations;
 
 public interface BinaryFunction<T, R> {
 
-    
     /**
      * Has to be implemented to perform the actual operation. The order of operands might be important or not,
      * depending, if the operation is commutative or not.

--- a/src/java/org/tensorics/core/math/operations/CommutativeOperation.java
+++ b/src/java/org/tensorics/core/math/operations/CommutativeOperation.java
@@ -29,8 +29,8 @@ package org.tensorics.core.math.operations;
  * 
  * @author kfuchsbe
  * @param <T>
- * @see <a
- *      href="http://en.wikipedia.org/wiki/Commutative_property">http://en.wikipedia.org/wiki/Commutative_property</a>
+ * @see <a href="http://en.wikipedia.org/wiki/Commutative_property">http://en.wikipedia.org/wiki/Commutative_property
+ *      </a>
  */
 public interface CommutativeOperation<T> extends BinaryOperation<T> {
     /* only a marker */

--- a/src/java/org/tensorics/core/math/predicates/BinaryPredicate.java
+++ b/src/java/org/tensorics/core/math/predicates/BinaryPredicate.java
@@ -34,7 +34,7 @@ public interface BinaryPredicate<T> extends BinaryFunction<T, Boolean> {
     /**
      * Evaluates the predicate (condition) on the given arguments.
      *
-     * @param left  the left operator of the condition
+     * @param left the left operator of the condition
      * @param right the right operator of the condition
      * @return {@code true} if the predicate is fulfilled, {@code false} otherwise.
      */

--- a/src/java/org/tensorics/core/math/structures/grouplike/CommutativeMonoid.java
+++ b/src/java/org/tensorics/core/math/structures/grouplike/CommutativeMonoid.java
@@ -28,8 +28,8 @@ package org.tensorics.core.math.structures.grouplike;
  * 
  * @author kfuchsbe
  * @param <T> The type of the elements of the underlying set
- * @see <a href="http://en.wikipedia.org/wiki/Commutative_monoid#Commutative_monoid">
- *      http://en.wikipedia.org/wiki/Commutative_monoid#Commutative_monoid</a>
+ * @see <a href="http://en.wikipedia.org/wiki/Commutative_monoid#Commutative_monoid"> http://en.wikipedia.org/wiki/
+ *      Commutative_monoid#Commutative_monoid</a>
  */
 public interface CommutativeMonoid<T> extends CommutativeSemigroup<T>, Monoid<T> {
     /* All operations defined from super interfaces */

--- a/src/java/org/tensorics/core/math/structures/grouplike/CommutativeSemigroup.java
+++ b/src/java/org/tensorics/core/math/structures/grouplike/CommutativeSemigroup.java
@@ -30,8 +30,8 @@ import org.tensorics.core.math.operations.CommutativeAssociativeOperation;
  * 
  * @author kfuchsbe
  * @param <T> the type of elements of the underlying set.
- * @see <a
- *      href="http://en.wikipedia.org/wiki/Commutative_semigroup">http://en.wikipedia.org/wiki/Commutative_semigroup</a>
+ * @see <a href="http://en.wikipedia.org/wiki/Commutative_semigroup">http://en.wikipedia.org/wiki/Commutative_semigroup
+ *      </a>
  */
 public interface CommutativeSemigroup<T> extends Semigroup<T> {
 

--- a/src/java/org/tensorics/core/quantity/ErronousValue.java
+++ b/src/java/org/tensorics/core/quantity/ErronousValue.java
@@ -26,7 +26,6 @@ import java.io.Serializable;
 
 import com.google.common.base.Optional;
 
-
 /**
  * A scalar value that additionally holds an error. The error type is the same as the value type.
  * 

--- a/src/java/org/tensorics/core/quantity/ImmutableQuantifiedValue.java
+++ b/src/java/org/tensorics/core/quantity/ImmutableQuantifiedValue.java
@@ -28,7 +28,6 @@ import org.tensorics.core.units.Unit;
 
 import com.google.common.base.Optional;
 
-
 /**
  * Groups a value together with its unit. Additionally an error and a validity flag can be provided. If the latter two
  * are not present explicitely given, then the validity will be {@code true} and the (optional) error will not be

--- a/src/java/org/tensorics/core/quantity/conditions/QuantityGreaterPredicate.java
+++ b/src/java/org/tensorics/core/quantity/conditions/QuantityGreaterPredicate.java
@@ -26,15 +26,15 @@ import org.tensorics.core.quantity.QuantifiedValue;
 import org.tensorics.core.quantity.options.QuantityEnvironment;
 
 /**
- * A condition to test if a quantity is greater than another quantity. In case at least one of the quantities has
- * an error, a statistical z-test is done at a given confidence level.
+ * A condition to test if a quantity is greater than another quantity. In case at least one of the quantities has an
+ * error, a statistical z-test is done at a given confidence level.
  * 
- * @author mihostet 
+ * @author mihostet
  * @param <S> the value of the scalar (elements of the field)
  */
 public class QuantityGreaterPredicate<S> extends AbstractQuantityStatisticPredicate<S> {
     final S confidenceLimit;
-    
+
     public QuantityGreaterPredicate(QuantityEnvironment<S> environment) {
         super(environment);
         confidenceLimit = inverseGaussianCumulativeDistributionFunction(environment.confidenceLevel());

--- a/src/java/org/tensorics/core/quantity/conditions/QuantityLessPredicate.java
+++ b/src/java/org/tensorics/core/quantity/conditions/QuantityLessPredicate.java
@@ -37,8 +37,8 @@ public class QuantityLessPredicate<S> extends AbstractQuantityStatisticPredicate
 
     public QuantityLessPredicate(QuantityEnvironment<S> environment) {
         super(environment);
-        confidenceLimit = inverseGaussianCumulativeDistributionFunction(calculate(one()).minus(
-                environment.confidenceLevel()));
+        confidenceLimit = inverseGaussianCumulativeDistributionFunction(
+                calculate(one()).minus(environment.confidenceLevel()));
     }
 
     @Override

--- a/src/java/org/tensorics/core/quantity/conditions/QuantityPedicateRepository.java
+++ b/src/java/org/tensorics/core/quantity/conditions/QuantityPedicateRepository.java
@@ -33,10 +33,10 @@ import org.tensorics.core.quantity.options.QuantityEnvironment;
  * @param <S> the type of the scalar values (elements of the field)
  */
 public class QuantityPedicateRepository<S> {
-    
+
     private final BinaryPredicate<QuantifiedValue<S>> lessCondition;
     private final BinaryPredicate<QuantifiedValue<S>> greaterCondition;
-    
+
     public QuantityPedicateRepository(QuantityEnvironment<S> environment) {
         lessCondition = new QuantityLessPredicate<S>(environment);
         greaterCondition = new QuantityGreaterPredicate<S>(environment);

--- a/src/java/org/tensorics/core/quantity/operations/AbstractQuantityOperation.java
+++ b/src/java/org/tensorics/core/quantity/operations/AbstractQuantityOperation.java
@@ -28,7 +28,6 @@ import org.tensorics.core.quantity.options.QuantityEnvironment;
 
 import com.google.common.base.Optional;
 
-
 /**
  * @author kfuchsbe
  * @param <V>

--- a/src/java/org/tensorics/core/quantity/operations/QuantityBinaryOperation.java
+++ b/src/java/org/tensorics/core/quantity/operations/QuantityBinaryOperation.java
@@ -33,8 +33,8 @@ import org.tensorics.core.quantity.options.QuantityEnvironment;
  * @author kfuchsbe
  * @param <V> the type of the scalar values on which all operations are based on (elements of a field)
  */
-public abstract class QuantityBinaryOperation<V> extends AbstractQuantityOperation<V> implements
-        BinaryOperation<QuantifiedValue<V>> {
+public abstract class QuantityBinaryOperation<V> extends AbstractQuantityOperation<V>
+        implements BinaryOperation<QuantifiedValue<V>> {
 
     private final BinaryOperation<V> scalarBinaryOeration;
 

--- a/src/java/org/tensorics/core/quantity/operations/QuantitySumOrDifferenceOperation.java
+++ b/src/java/org/tensorics/core/quantity/operations/QuantitySumOrDifferenceOperation.java
@@ -31,7 +31,6 @@ import org.tensorics.core.units.Unit;
 
 import com.google.common.base.Optional;
 
-
 /**
  * Base class for operations on physical quantities, that can perform sum or difference, depending on the scalar
  * operation that is passed into the constructor. The left and right operand will be converted to the same unit (if they

--- a/src/java/org/tensorics/core/quantity/operations/QuantityUnaryOperation.java
+++ b/src/java/org/tensorics/core/quantity/operations/QuantityUnaryOperation.java
@@ -32,8 +32,8 @@ import org.tensorics.core.quantity.options.QuantityEnvironment;
  * @author kfuchsbe
  * @param <S> the type of the scalar values (field elements) on which all the operations are based on
  */
-public abstract class QuantityUnaryOperation<S> extends AbstractQuantityOperation<S> implements
-        UnaryOperation<QuantifiedValue<S>> {
+public abstract class QuantityUnaryOperation<S> extends AbstractQuantityOperation<S>
+        implements UnaryOperation<QuantifiedValue<S>> {
 
     protected QuantityUnaryOperation(QuantityEnvironment<S> environment) {
         super(environment);

--- a/src/java/org/tensorics/core/quantity/options/ConfidenceLevel.java
+++ b/src/java/org/tensorics/core/quantity/options/ConfidenceLevel.java
@@ -27,7 +27,7 @@ import org.tensorics.core.commons.options.ManipulationOption;
 /**
  * {@link ManipulationOption} to allow setting a confidence level for statistical tests.
  * 
- * @author mihostet 
+ * @author mihostet
  * @param <S>
  */
 public interface ConfidenceLevel<S> extends ManipulationOption {

--- a/src/java/org/tensorics/core/quantity/options/ErrorPropagationStrategy.java
+++ b/src/java/org/tensorics/core/quantity/options/ErrorPropagationStrategy.java
@@ -27,7 +27,6 @@ import org.tensorics.core.quantity.ErronousValue;
 
 import com.google.common.base.Optional;
 
-
 /**
  * Instances of this class define, how the errors have to be propagated in different situations.
  * <p>

--- a/src/java/org/tensorics/core/quantity/options/ImmutableConfidenceLevel.java
+++ b/src/java/org/tensorics/core/quantity/options/ImmutableConfidenceLevel.java
@@ -29,7 +29,7 @@ import org.tensorics.core.commons.options.ManipulationOption;
 /**
  * Default immutable implementation of {@link ConfidenceLevel} to hold the value set by the user.
  * 
- * @author mihostet 
+ * @author mihostet
  * @param <S>
  */
 public class ImmutableConfidenceLevel<S> implements ConfidenceLevel<S> {

--- a/src/java/org/tensorics/core/quantity/options/QuantificationStrategy.java
+++ b/src/java/org/tensorics/core/quantity/options/QuantificationStrategy.java
@@ -40,9 +40,9 @@ public interface QuantificationStrategy<T> extends ManipulationOption {
     Unit multiply(Unit left, Unit right);
 
     Unit divide(Unit left, Unit right);
-    
+
     Unit root(Unit left, T right);
-    
+
     Unit power(Unit unit, T value);
 
     Unit one();

--- a/src/java/org/tensorics/core/quantity/options/QuantityEnvironment.java
+++ b/src/java/org/tensorics/core/quantity/options/QuantityEnvironment.java
@@ -36,7 +36,7 @@ public interface QuantityEnvironment<S> extends Environment<S> {
     ErrorPropagationStrategy<S> errorPropagation();
 
     QuantificationStrategy<S> quantification();
-    
+
     S confidenceLevel();
 
 }

--- a/src/java/org/tensorics/core/quantity/options/UncorrelatedErrorPropagationStrategy.java
+++ b/src/java/org/tensorics/core/quantity/options/UncorrelatedErrorPropagationStrategy.java
@@ -28,7 +28,6 @@ import org.tensorics.core.scalar.lang.ScalarSupport;
 
 import com.google.common.base.Optional;
 
-
 /**
  * This error propagation assumes uncorrelated errors.
  * <p>
@@ -38,7 +37,7 @@ import com.google.common.base.Optional;
  * @author kfuchsbe
  * @param <V>
  */
-public class UncorrelatedErrorPropagationStrategy<V> extends ScalarSupport<V> implements ErrorPropagationStrategy<V> {
+public class UncorrelatedErrorPropagationStrategy<V> extends ScalarSupport<V>implements ErrorPropagationStrategy<V> {
 
     public UncorrelatedErrorPropagationStrategy(ExtendedField<V> field) {
         super(field);

--- a/src/java/org/tensorics/core/reduction/AbstractLinearDoubleInterpolationStrategy.java
+++ b/src/java/org/tensorics/core/reduction/AbstractLinearDoubleInterpolationStrategy.java
@@ -22,8 +22,7 @@ import org.tensorics.core.tensor.Tensor;
  * @author agorzaws
  * @param <C> type of the coordinate, must be the {@link Comparable}
  */
-public abstract class AbstractLinearDoubleInterpolationStrategy<C> extends
-        AbstractInterpolationStrategy<C, Double> {
+public abstract class AbstractLinearDoubleInterpolationStrategy<C> extends AbstractInterpolationStrategy<C, Double> {
 
     public AbstractLinearDoubleInterpolationStrategy(Comparator<C> comparator) {
         super(comparator);

--- a/src/java/org/tensorics/core/reduction/Averaging.java
+++ b/src/java/org/tensorics/core/reduction/Averaging.java
@@ -32,7 +32,7 @@ import org.tensorics.core.tensor.Position;
  * @author kfuchsbe
  * @param <V> the type of the elements of the field.
  */
-public class Averaging<V> extends ScalarIterableSupport<V> implements ReductionStrategy<Object, V, V> {
+public class Averaging<V> extends ScalarIterableSupport<V>implements ReductionStrategy<Object, V, V> {
 
     public Averaging(ExtendedField<V> field) {
         super(field);

--- a/src/java/org/tensorics/core/reduction/RootMeanSquare.java
+++ b/src/java/org/tensorics/core/reduction/RootMeanSquare.java
@@ -34,7 +34,7 @@ import org.tensorics.core.tensor.Position;
  * @author kfuchsbe
  * @param <S> the type of the scalars (field elements) on which all the operations are based on.
  */
-public class RootMeanSquare<S> extends ScalarIterableSupport<S> implements ReductionStrategy<Object, S, S> {
+public class RootMeanSquare<S> extends ScalarIterableSupport<S>implements ReductionStrategy<Object, S, S> {
 
     public RootMeanSquare(ExtendedField<S> field) {
         super(field);

--- a/src/java/org/tensorics/core/reduction/ToFunctions.java
+++ b/src/java/org/tensorics/core/reduction/ToFunctions.java
@@ -11,8 +11,8 @@ import org.tensorics.core.function.MapBackedDiscreteFunction;
 import org.tensorics.core.tensor.Position;
 
 /**
- * A reduction strategy which reduces all elements of dimension {@code <X>} by transforming them into a {@link DiscreteFunction}
- * s from {@code <X>} to {@code <Y>}
+ * A reduction strategy which reduces all elements of dimension {@code <X>} by transforming them into a
+ * {@link DiscreteFunction} s from {@code <X>} to {@code <Y>}
  * 
  * @author kfuchsbe, caguiler
  * @param <X> the type of the values along the X-axis, the type of coordinate (aka 'the dimension') do be reduced

--- a/src/java/org/tensorics/core/resolve/engine/BiggestSubTreeDispatcher.java
+++ b/src/java/org/tensorics/core/resolve/engine/BiggestSubTreeDispatcher.java
@@ -162,9 +162,9 @@ public class BiggestSubTreeDispatcher implements Dispatcher {
                 try {
                     resolveNode(expression, context, resolverSetlection);
                 } catch (final RuntimeException e) {
-                    exceptionHandling.handleWithRootNodeFailingNodeException(ExceptionHandlingRequest.builder()
-                            .withRoot(rootNode).withThrowingNode(expression).withException(e).withContext(context)
-                            .build());
+                    exceptionHandling.handleWithRootNodeFailingNodeException(
+                            ExceptionHandlingRequest.builder().withRoot(rootNode).withThrowingNode(expression)
+                                    .withException(e).withContext(context).build());
                 }
             }
             return context;

--- a/src/java/org/tensorics/core/resolve/engine/DefaultResolvingEngine.java
+++ b/src/java/org/tensorics/core/resolve/engine/DefaultResolvingEngine.java
@@ -54,7 +54,8 @@ public class DefaultResolvingEngine implements ResolvingEngine {
     }
 
     @Override
-    public <R, E extends Expression<R>> DetailedExpressionResult<R, E> resolveDetailed(E rootNode, ResolvingOption... options) {
+    public <R, E extends Expression<R>> DetailedExpressionResult<R, E> resolveDetailed(E rootNode,
+            ResolvingOption... options) {
         return resolveDetailed(rootNode, Contexts.newResolvingContext(), options);
     }
 

--- a/src/java/org/tensorics/core/resolve/engine/ResolvingEngine.java
+++ b/src/java/org/tensorics/core/resolve/engine/ResolvingEngine.java
@@ -41,6 +41,6 @@ public interface ResolvingEngine {
 
     <R, E extends Expression<R>> DetailedExpressionResult<R, E> resolveDetailed(E rootNode, ResolvingOption... options);
 
-    <R, E extends Expression<R>> DetailedExpressionResult<R, E> resolveDetailed(E rootNode, ResolvingContext initialContext,
-            ResolvingOption... options);
+    <R, E extends Expression<R>> DetailedExpressionResult<R, E> resolveDetailed(E rootNode,
+            ResolvingContext initialContext, ResolvingOption... options);
 }

--- a/src/java/org/tensorics/core/resolve/options/HandleWithFirstCapableAncestorStrategy.java
+++ b/src/java/org/tensorics/core/resolve/options/HandleWithFirstCapableAncestorStrategy.java
@@ -56,7 +56,8 @@ public class HandleWithFirstCapableAncestorStrategy extends AbstractExceptionHan
         if (handlingNodes.isEmpty()) {
             throw new ResolvingException(
                     "No node could be found to handle exception which occured during the processing of node '"
-                            + parameterObject.getThrowingNode() + "'.", parameterObject.getException());
+                            + parameterObject.getThrowingNode() + "'.",
+                    parameterObject.getException());
         }
         for (ExceptionHandlingNode<?> handlingNode : handlingNodes) {
             putHandled(parameterObject.getException(), handlingNode, parameterObject.getContext());

--- a/src/java/org/tensorics/core/resolve/options/ResolvingOptions.java
+++ b/src/java/org/tensorics/core/resolve/options/ResolvingOptions.java
@@ -42,8 +42,8 @@ public final class ResolvingOptions {
     /**
      * The list of default options.
      */
-    private static final ImmutableList<ResolvingOption> DEFAULT_OPTIONS = ImmutableList.<ResolvingOption> of(
-            new RethrowExceptionHandlingStrategy(), new TakeFirstResolverSelectionStrategy());
+    private static final ImmutableList<ResolvingOption> DEFAULT_OPTIONS = ImmutableList
+            .<ResolvingOption> of(new RethrowExceptionHandlingStrategy(), new TakeFirstResolverSelectionStrategy());
 
     private ResolvingOptions() {
         /* only static methods */

--- a/src/java/org/tensorics/core/resolve/options/RethrowExceptionHandlingStrategy.java
+++ b/src/java/org/tensorics/core/resolve/options/RethrowExceptionHandlingStrategy.java
@@ -37,8 +37,9 @@ public class RethrowExceptionHandlingStrategy extends AbstractExceptionHandlingS
 
     @Override
     public void handleWithRootNodeFailingNodeException(ExceptionHandlingRequest parameterObject) {
-        throw new ResolvingException("Exception occured during processing of node '"
-                + parameterObject.getThrowingNode() + "'.", parameterObject.getException());
+        throw new ResolvingException(
+                "Exception occured during processing of node '" + parameterObject.getThrowingNode() + "'.",
+                parameterObject.getException());
     }
 
 }

--- a/src/java/org/tensorics/core/resolve/resolvers/BinaryPredicateIterableResolver.java
+++ b/src/java/org/tensorics/core/resolve/resolvers/BinaryPredicateIterableResolver.java
@@ -32,7 +32,8 @@ import org.tensorics.core.tree.domain.ResolvingContext;
  * @param <T> the input type of the expression
  * @author caguiler
  */
-public class BinaryPredicateIterableResolver<T> extends AbstractResolver<Boolean, BinaryPredicateIterableExpression<T>> {
+public class BinaryPredicateIterableResolver<T>
+        extends AbstractResolver<Boolean, BinaryPredicateIterableExpression<T>> {
 
     @Override
     public boolean canResolve(BinaryPredicateIterableExpression<T> expression, ResolvingContext context) {
@@ -44,6 +45,7 @@ public class BinaryPredicateIterableResolver<T> extends AbstractResolver<Boolean
         Iterable<T> left = context.resolvedValueOf(expression.getLeft());
         T right = context.resolvedValueOf(expression.getRight());
         BinaryPredicate<T> predicate = expression.getPredicate();
-        return StreamSupport.stream(left.spliterator(),true).allMatch(leftElement -> predicate.test(leftElement,right));
+        return StreamSupport.stream(left.spliterator(), true)
+                .allMatch(leftElement -> predicate.test(leftElement, right));
     }
 }

--- a/src/java/org/tensorics/core/resolve/resolvers/FunctionalExpressionResolver.java
+++ b/src/java/org/tensorics/core/resolve/resolvers/FunctionalExpressionResolver.java
@@ -7,7 +7,6 @@ package org.tensorics.core.resolve.resolvers;
 import org.tensorics.core.functional.expressions.FunctionalExpression;
 import org.tensorics.core.tree.domain.ResolvingContext;
 
-
 public class FunctionalExpressionResolver<R> extends AbstractResolver<R, FunctionalExpression<R>> {
 
     @Override

--- a/src/java/org/tensorics/core/resolve/resolvers/PickResolver.java
+++ b/src/java/org/tensorics/core/resolve/resolvers/PickResolver.java
@@ -12,10 +12,10 @@ import org.tensorics.core.tree.domain.ResolvingContext;
  * Resolver for {@link PickExpression} expression.
  * 
  * @see PickExpression
- * @author acalia 
+ * @author acalia
  * @param <T> the type of the data to pick
  */
-public class PickResolver<T> extends AbstractResolver<T, PickExpression<T>>{
+public class PickResolver<T> extends AbstractResolver<T, PickExpression<T>> {
 
     @Override
     public boolean canResolve(PickExpression<T> expression, ResolvingContext context) {
@@ -27,7 +27,7 @@ public class PickResolver<T> extends AbstractResolver<T, PickExpression<T>>{
         Iterable<T> iterable = context.resolvedValueOf(expression.iterableExpression());
         Mode mode = expression.mode();
         int offset = expression.offset();
-        
+
         return mode.pick(iterable, offset);
     }
 

--- a/src/java/org/tensorics/core/tensor/AbstractScalar.java
+++ b/src/java/org/tensorics/core/tensor/AbstractScalar.java
@@ -1,0 +1,40 @@
+package org.tensorics.core.tensor;
+
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+
+/**
+ * A base class for scalars, that already guarantees the shape and the correct
+ * delegation of the get() methods to the value method.
+ * 
+ * @author kaifox
+ *
+ * @param <V>
+ *            the type of the value of the scalar
+ */
+public abstract class AbstractScalar<V> implements Scalar<V> {
+
+	@Override
+	public final V get(Position position) {
+		if (Position.empty().equals(position)) {
+			return value();
+		}
+		throw new NoSuchElementException("A scalar contains exactly one value (for the 'empty' position). "
+				+ "However, it contains no value for the requested position '" + position + "'");
+	}
+
+	@Override
+	public final V get(Object... coordinates) {
+		if (coordinates.length == 0) {
+			return value();
+		}
+		throw new NoSuchElementException("A scalar contains exactly one value (for the 'empty' position). "
+				+ "However, it contains no value for the requested coordinates '" + Arrays.toString(coordinates) + "'");
+	}
+
+	@Override
+	public final Shape shape() {
+		return Shape.zeroDimensional();
+	}
+
+}

--- a/src/java/org/tensorics/core/tensor/AbstractScalar.java
+++ b/src/java/org/tensorics/core/tensor/AbstractScalar.java
@@ -6,39 +6,37 @@ import java.util.Arrays;
 import java.util.NoSuchElementException;
 
 /**
- * A base class for scalars, that already guarantees the shape and the correct
- * delegation of the get() methods to the value method.
- * 
- * @author kaifox
+ * A base class for scalars, that already guarantees the shape and the correct delegation of the get() methods to the
+ * value method.
  *
- * @param <V>
- *            the type of the value of the scalar
+ * @author kaifox
+ * @param <V> the type of the value of the scalar
  */
-public abstract class AbstractScalar<V> implements Scalar<V> {
+public abstract class AbstractScalar<V> extends AbstractTensor<V>implements Scalar<V> {
 
-	@Override
-	public final V get(Position position) {
-		requireNonNull(position, "position must not be null");
-		if (Position.empty().equals(position)) {
-			return value();
-		}
-		throw new NoSuchElementException("A scalar contains exactly one value (for the 'empty' position). "
-				+ "However, it contains no value for the requested position '" + position + "'");
-	}
+    @Override
+    public final V get(Position position) {
+        requireNonNull(position, "position must not be null");
+        if (Position.empty().equals(position)) {
+            return value();
+        }
+        throw new NoSuchElementException("A scalar contains exactly one value (for the 'empty' position). "
+                + "However, it contains no value for the requested position '" + position + "'");
+    }
 
-	@Override
-	public final V get(Object... coordinates) {
-		requireNonNull(coordinates, "coordinates must not be null");
-		if (coordinates.length == 0) {
-			return value();
-		}
-		throw new NoSuchElementException("A scalar contains exactly one value (for the 'empty' position). "
-				+ "However, it contains no value for the requested coordinates '" + Arrays.toString(coordinates) + "'");
-	}
+    @Override
+    public final V get(Object... coordinates) {
+        requireNonNull(coordinates, "coordinates must not be null");
+        if (coordinates.length == 0) {
+            return value();
+        }
+        throw new NoSuchElementException("A scalar contains exactly one value (for the 'empty' position). "
+                + "However, it contains no value for the requested coordinates '" + Arrays.toString(coordinates) + "'");
+    }
 
-	@Override
-	public final Shape shape() {
-		return Shape.zeroDimensional();
-	}
+    @Override
+    public final Shape shape() {
+        return Shape.zeroDimensional();
+    }
 
 }

--- a/src/java/org/tensorics/core/tensor/AbstractScalar.java
+++ b/src/java/org/tensorics/core/tensor/AbstractScalar.java
@@ -1,5 +1,7 @@
 package org.tensorics.core.tensor;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Arrays;
 import java.util.NoSuchElementException;
 
@@ -16,6 +18,7 @@ public abstract class AbstractScalar<V> implements Scalar<V> {
 
 	@Override
 	public final V get(Position position) {
+		requireNonNull(position, "position must not be null");
 		if (Position.empty().equals(position)) {
 			return value();
 		}
@@ -25,6 +28,7 @@ public abstract class AbstractScalar<V> implements Scalar<V> {
 
 	@Override
 	public final V get(Object... coordinates) {
+		requireNonNull(coordinates, "coordinates must not be null");
 		if (coordinates.length == 0) {
 			return value();
 		}

--- a/src/java/org/tensorics/core/tensor/AbstractTensor.java
+++ b/src/java/org/tensorics/core/tensor/AbstractTensor.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2017 European Organisation for Nuclear Research (CERN), All Rights Reserved.
+ */
+
+package org.tensorics.core.tensor;
+
+import static org.tensorics.core.tensor.operations.TensorInternals.mapFrom;
+
+import java.util.Map;
+
+/**
+ * Provides sceletal behaviour of tensors. It is highly recommended that all implementations of this tensor inherit from
+ * this class. This is particularly important in order to respect the equality of tensors.
+ *
+ * @author kfuchsbe
+ * @param <V> the type of the values of the tensor
+ */
+public abstract class AbstractTensor<V> implements Tensor<V> {
+
+    @Override
+    public final int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        Position context = context();
+        result = prime * result + ((context == null) ? 0 : context.hashCode());
+        Shape shape = shape();
+        result = prime * result + ((shape == null) ? 0 : shape.hashCode());
+        Map<Position, V> map = mapFrom(this);
+        result = prime * result + ((map == null) ? 0 : map.hashCode());
+        return result;
+    }
+
+    @Override
+    public final boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof Tensor)) {
+            return false;
+        }
+        Tensor<?> other = (Tensor<?>) obj;
+        if (context() == null) {
+            if (other.context() != null) {
+                return false;
+            }
+        } else if (!context().equals(other.context())) {
+            return false;
+        }
+        if (shape() == null) {
+            if (other.shape() != null) {
+                return false;
+            }
+        } else if (!shape().equals(other.shape())) {
+            return false;
+        }
+        Map<Position, V> map = mapFrom(this);
+        if (map == null) {
+            if (mapFrom(other) != null) {
+                return false;
+            }
+        } else if (!map.equals(mapFrom(other))) {
+            return false;
+        }
+
+        return true;
+    }
+
+}

--- a/src/java/org/tensorics/core/tensor/AbstractTensorBuilder.java
+++ b/src/java/org/tensorics/core/tensor/AbstractTensorBuilder.java
@@ -34,115 +34,113 @@ import com.google.common.collect.ImmutableSet;
 
 /**
  * @author kfuchsbe
- * @param <E>
- *            the type of the elements of the tensor to build
+ * @param <E> the type of the elements of the tensor to build
  */
 public abstract class AbstractTensorBuilder<E> implements TensorBuilder<E> {
 
-	private final Set<Class<?>> dimensions;
-	private final VerificationCallback<E> callback;
-	private Position context = Position.empty();
+    private final Set<Class<?>> dimensions;
+    private final VerificationCallback<E> callback;
+    private Position context = Position.empty();
 
-	public AbstractTensorBuilder(Set<Class<?>> dimensions, VerificationCallback<E> callback) {
-		Preconditions.checkArgument(dimensions != null, "Argument '" + "dimensions" + "' must not be null!");
-		Preconditions.checkArgument(callback != null, "Argument '" + "callback" + "' must not be null!");
-		Coordinates.checkClassesRelations(dimensions);
-		this.dimensions = ImmutableSet.copyOf(dimensions);
-		this.callback = callback;
-	}
+    public AbstractTensorBuilder(Set<Class<?>> dimensions, VerificationCallback<E> callback) {
+        Preconditions.checkArgument(dimensions != null, "Argument '" + "dimensions" + "' must not be null!");
+        Preconditions.checkArgument(callback != null, "Argument '" + "callback" + "' must not be null!");
+        Coordinates.checkClassesRelations(dimensions);
+        this.dimensions = ImmutableSet.copyOf(dimensions);
+        this.callback = callback;
+    }
 
-	public AbstractTensorBuilder(Set<Class<?>> dimensions) {
-		this(dimensions, new VerificationCallback<E>() {
+    public AbstractTensorBuilder(Set<Class<?>> dimensions) {
+        this(dimensions, new VerificationCallback<E>() {
 
-			@Override
-			public void verify(E scalar) {
-				/* Nothing to do */
-			}
-		});
-	}
+            @Override
+            public void verify(E scalar) {
+                /* Nothing to do */
+            }
+        });
+    }
 
-	/**
-	 * Prepares to set a value at given position (a combined set of coordinates)
-	 * 
-	 * @param entryPosition
-	 *            on which future value will be placed.
-	 * @return builder object to be able to put Value in.
-	 */
-	public final OngoingPut<E> at(Position entryPosition) {
-		return new OngoingPut<E>(entryPosition, this);
-	}
+    /**
+     * Prepares to set a value at given position (a combined set of coordinates)
+     * 
+     * @param entryPosition on which future value will be placed.
+     * @return builder object to be able to put Value in.
+     */
+    public final OngoingPut<E> at(Position entryPosition) {
+        return new OngoingPut<E>(entryPosition, this);
+    }
 
-	@Override
-	public final void putAt(E value, Position position) {
-		Preconditions.checkNotNull(value, "value must not be null!");
-		Preconditions.checkNotNull(position, "position must not be null");
-		Positions.assertConsistentDimensions(position, this.dimensions);
-		this.callback.verify(value);
-		this.putItAt(value, position);
-	}
+    @Override
+    public final void putAt(E value, Position position) {
+        Preconditions.checkNotNull(value, "value must not be null!");
+        Preconditions.checkNotNull(position, "position must not be null");
+        Positions.assertConsistentDimensions(position, this.dimensions);
+        this.callback.verify(value);
+        this.putItAt(value, position);
+    }
 
-	protected abstract void putItAt(E value, Position position);
+    protected abstract void putItAt(E value, Position position);
 
-	@Override
-	public final void putAt(E value, Object... coordinates) {
-		this.putAt(value, Position.of(coordinates));
-	}
+    @Override
+    public final void putAt(E value, Object... coordinates) {
+        this.putAt(value, Position.of(coordinates));
+    }
 
-	@Override
-	public void putAt(E value, Set<?> coordinates) {
-		putAt(value, Position.of(coordinates));
-	}
+    @Override
+    public void putAt(E value, Set<?> coordinates) {
+        putAt(value, Position.of(coordinates));
+    }
 
-	@Override
-	public void putAllAt(Tensor<E> tensor, Set<?> coordinates) {
-		putAllAt(tensor, Position.of(coordinates));
-	}
+    @Override
+    public void putAllAt(Tensor<E> tensor, Set<?> coordinates) {
+        putAllAt(tensor, Position.of(coordinates));
+    }
 
-	@Override
-	public void context(Position newContext) {
-		Preconditions.checkNotNull(newContext, "context must not be null");
-		checkIfContextValid(newContext);
-		this.context = newContext;
-	}
+    @Override
+    public void context(Position newContext) {
+        Preconditions.checkNotNull(newContext, "context must not be null");
+        checkIfContextValid(newContext);
+        this.context = newContext;
+    }
 
-	private void checkIfContextValid(Position context2) {
-		for (Class<?> oneDimensionClass : context2.dimensionSet()) {
-			if (dimensions.contains(oneDimensionClass)) {
-				throw new IllegalStateException("Inconsistent state: " + oneDimensionClass
-						+ " you are trying to put in to context is a BASE dimension of the tensor!");
-			}
-		}
-	}
+    private void checkIfContextValid(Position context2) {
+        for (Class<?> oneDimensionClass : context2.dimensionSet()) {
+            if (dimensions.contains(oneDimensionClass)) {
+                throw new IllegalStateException("Inconsistent state: " + oneDimensionClass
+                        + " you are trying to put in to context is a BASE dimension of the tensor!");
+            }
+        }
+    }
 
-	public final OngoingPut<E> at(Set<?> coordinates) {
-		return this.at(Position.of(coordinates));
-	}
+    public final OngoingPut<E> at(Set<?> coordinates) {
+        return this.at(Position.of(coordinates));
+    }
 
-	@SafeVarargs
-	public final OngoingPut<E> at(Object... coordinates) {
-		return this.at(Position.of(coordinates));
-	}
+    @SafeVarargs
+    public final OngoingPut<E> at(Object... coordinates) {
+        return this.at(Position.of(coordinates));
+    }
 
-	@Override
-	public final void putAllAt(Tensor<E> tensor, Position position) {
-		checkNotNull(tensor, "The tensor must not be null!");
-		checkNotNull(position, "The position must not be null!");
-		for (Entry<Position, E> entry : TensorInternals.mapFrom(tensor).entrySet()) {
-			putAt(entry.getValue(), Positions.union(position, entry.getKey()));
-		}
-	}
+    @Override
+    public final void putAllAt(Tensor<E> tensor, Position position) {
+        checkNotNull(tensor, "The tensor must not be null!");
+        checkNotNull(position, "The position must not be null!");
+        for (Entry<Position, E> entry : TensorInternals.mapFrom(tensor).entrySet()) {
+            putAt(entry.getValue(), Positions.union(position, entry.getKey()));
+        }
+    }
 
-	@Override
-	@SafeVarargs
-	public final void putAllAt(Tensor<E> tensor, Object... coordinates) {
-		putAllAt(tensor, Position.of(coordinates));
-	}
+    @Override
+    @SafeVarargs
+    public final void putAllAt(Tensor<E> tensor, Object... coordinates) {
+        putAllAt(tensor, Position.of(coordinates));
+    }
 
-	public Set<Class<?>> dimensions() {
-		return dimensions;
-	}
+    public Set<Class<?>> dimensions() {
+        return dimensions;
+    }
 
-	public Position context() {
-		return this.context;
-	}
+    public Position context() {
+        return this.context;
+    }
 }

--- a/src/java/org/tensorics/core/tensor/BroadcastedTensorView.java
+++ b/src/java/org/tensorics/core/tensor/BroadcastedTensorView.java
@@ -2,7 +2,7 @@
  /*******************************************************************************
  *
  * This file is part of tensorics.
- * 
+ *
  * Copyright (c) 2008-2011, CERN. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  ******************************************************************************/
 // @formatter:on
 
@@ -28,77 +28,67 @@ import static org.tensorics.core.tensor.Shapes.outerProduct;
 import org.tensorics.core.tensor.Positions.DimensionStripper;
 
 /**
- * Lets a tensors appear as a tensor with a bigger shape. The final
- * ('broadcasted') shape of the tensor has more dimensions as the original
- * tensor and is the outer product of the original shape and an additional shape
- * passed into the view. The original set and the passed in shape have to be
- * disjunct in dimensions, i.e. there must be no dimension which appears in both
- * of them.
+ * Lets a tensors appear as a tensor with a bigger shape. The final ('broadcasted') shape of the tensor has more
+ * dimensions as the original tensor and is the outer product of the original shape and an additional shape passed into
+ * the view. The original set and the passed in shape have to be disjunct in dimensions, i.e. there must be no dimension
+ * which appears in both of them.
  * <p>
- * The values are broadcasted such that the values will be the same for all
- * coordinates of the new dimensions.
+ * The values are broadcasted such that the values will be the same for all coordinates of the new dimensions.
  * <p>
- * The resulting view will still be backed by the original tensor. Since the
- * broadcasted shape will never be updated from the original tensor, the results
- * might be unpredictable, if the original tensor would be mutable.
- * 
+ * The resulting view will still be backed by the original tensor. Since the broadcasted shape will never be updated
+ * from the original tensor, the results might be unpredictable, if the original tensor would be mutable.
+ *
  * @author agorzaws
  * @author kfuchsbe
- * @param <V>
- *            the type of the values of the tensor
+ * @param <V> the type of the values of the tensor
  */
-public final class BroadcastedTensorView<V> implements Tensor<V> {
+public final class BroadcastedTensorView<V> extends AbstractTensor<V> {
 
-	/** The original (smaller) tensor */
-	private final Tensor<V> originalTensor;
+    /** The original (smaller) tensor */
+    private final Tensor<V> originalTensor;
 
-	/** The shape, how the tensor will appear */
-	private final Shape broadcastedShape;
+    /** The shape, how the tensor will appear */
+    private final Shape broadcastedShape;
 
-	/**
-	 * The stripper instance to be used for the position-transformation from the
-	 * bigger shape to the original
-	 */
-	private final DimensionStripper dimensionStripper;
+    /**
+     * The stripper instance to be used for the position-transformation from the bigger shape to the original
+     */
+    private final DimensionStripper dimensionStripper;
 
-	/**
-	 * Constructs a view of the given original tensor, broadcasted to the
-	 * additional shape.
-	 * 
-	 * @param originalTensor
-	 *            the original tensor
-	 * @param extendingShape
-	 *            the shape by which the original tensor shape has to be
-	 *            enlarged
-	 */
-	public BroadcastedTensorView(Tensor<V> originalTensor, Shape extendingShape) {
-		this.originalTensor = originalTensor;
-		this.broadcastedShape = outerProduct(originalTensor.shape(), extendingShape);
-		this.dimensionStripper = stripping(extendingShape.dimensionSet());
-	}
+    /**
+     * Constructs a view of the given original tensor, broadcasted to the additional shape.
+     *
+     * @param originalTensor the original tensor
+     * @param extendingShape the shape by which the original tensor shape has to be enlarged
+     */
+    public BroadcastedTensorView(Tensor<V> originalTensor, Shape extendingShape) {
+        this.originalTensor = originalTensor;
+        this.broadcastedShape = outerProduct(originalTensor.shape(), extendingShape);
+        this.dimensionStripper = stripping(extendingShape.dimensionSet());
+    }
 
-	@Override
-	public V get(Position position) {
-		return originalTensor.get(toOriginal(position));
-	}
+    @Override
+    public V get(Position position) {
+        return originalTensor.get(toOriginal(position));
+    }
 
-	@Override
-	public V get(Object... coordinates) {
-		return get(Position.of(coordinates));
-	}
+    @Override
+    public V get(Object... coordinates) {
+        return get(Position.of(coordinates));
+    }
 
-	private Position toOriginal(Position position) {
-		return dimensionStripper.apply(position);
-	}
+    private Position toOriginal(Position position) {
+        return dimensionStripper.apply(position);
+    }
 
-	@Override
-	public Shape shape() {
-		return this.broadcastedShape;
-	}
+    @Override
+    public Shape shape() {
+        return this.broadcastedShape;
+    }
 
-	@Override
-	public Position context() {
-		return originalTensor.context();
-	}
+    @Override
+    public Position context() {
+        return originalTensor.context();
+    }
 
 }

--- a/src/java/org/tensorics/core/tensor/ImmutableScalar.java
+++ b/src/java/org/tensorics/core/tensor/ImmutableScalar.java
@@ -5,128 +5,77 @@ import static java.util.Objects.requireNonNull;
 import java.io.Serializable;
 
 /**
- * An immutable implementation of a scalar (a tensor with zero dimensions and
- * exactly one value). To construct a simple scalar (with an empty context), use
- * the {@link #of(Object)} method. An immutable scalar with a non-empty context
- * can be created by chaining the {@link #of(Object)} method with the
- * {@link #withContext(Position)} method.
- * 
- * @author kaifox
+ * An immutable implementation of a scalar (a tensor with zero dimensions and exactly one value). To construct a simple
+ * scalar (with an empty context), use the {@link #of(Object)} method. An immutable scalar with a non-empty context can
+ * be created by chaining the {@link #of(Object)} method with the {@link #withContext(Position)} method.
  *
- * @param <V>
- *            the type of the value of the scalar
+ * @author kaifox
+ * @param <V> the type of the value of the scalar
  */
-public final class ImmutableScalar<V> extends AbstractScalar<V> implements Serializable {
-	private static final long serialVersionUID = 1L;
+public final class ImmutableScalar<V> extends AbstractScalar<V>implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-	private final V value;
-	private final Position context;
+    private final V value;
+    private final Position context;
 
-	/**
-	 * Should not be used directly. Use the factory method {@link #of(Object)}
-	 * 
-	 * @param value
-	 *            the value of the scalar
-	 * @param context
-	 *            the context of the new scalar
-	 */
-	private ImmutableScalar(V value, Position context) {
-		this.value = requireNonNull(value, "value must not be null");
-		this.context = requireNonNull(context, "context must not be null");
-	}
+    /**
+     * Should not be used directly. Use the factory method {@link #of(Object)}
+     *
+     * @param value the value of the scalar
+     * @param context the context of the new scalar
+     */
+    private ImmutableScalar(V value, Position context) {
+        this.value = requireNonNull(value, "value must not be null");
+        this.context = requireNonNull(context, "context must not be null");
+    }
 
-	/**
-	 * Factory method for a scalar with an empty context.
-	 * 
-	 * @param value
-	 *            the value of the scalar
-	 * @return a new scalar with the given value
-	 * @throws NullPointerException
-	 *             if the given value is {@code null}
-	 */
-	public static <V> ImmutableScalar<V> of(V value) {
-		return new ImmutableScalar<V>(value, Position.empty());
-	}
+    /**
+     * Factory method for a scalar with an empty context.
+     *
+     * @param value the value of the scalar
+     * @return a new scalar with the given value
+     * @throws NullPointerException if the given value is {@code null}
+     */
+    public static <V> ImmutableScalar<V> of(V value) {
+        return new ImmutableScalar<>(value, Position.empty());
+    }
 
-	/**
-	 * Returns a new scalar with the same value as this scalar, but the context
-	 * overridden by the given one.
-	 * 
-	 * @param context
-	 *            the context for the new scalar instance
-	 * @return a new immutable scalar with the new context
-	 * @throws NullPointerException
-	 *             if the given context is {@code null}
-	 */
-	public final ImmutableScalar<V> withContext(Position context) {
-		return new ImmutableScalar<>(this.value, context);
-	}
+    /**
+     * Returns a new scalar with the same value as this scalar, but the context overridden by the given one.
+     *
+     * @param newContext the context for the new scalar instance
+     * @return a new immutable scalar with the new context
+     * @throws NullPointerException if the given context is {@code null}
+     */
+    public final ImmutableScalar<V> withContext(Position newContext) {
+        return new ImmutableScalar<>(this.value, newContext);
+    }
 
-	/**
-	 * Returns a new scalar with the same value as this scalar, but the context
-	 * overridden by a position constructed from the given coordinates.
-	 * 
-	 * @param coordinates
-	 *            the coordinates for the context of the new scalar instance
-	 * @return a new immutable scalar with the new context
-	 * @throws NullPointerException
-	 *             if the given context is {@code null}
-	 */
-	public final ImmutableScalar<V> withContext(Object... coordinates) {
-		return withContext(Position.of(coordinates));
-	}
+    /**
+     * Returns a new scalar with the same value as this scalar, but the context overridden by a position constructed
+     * from the given coordinates.
+     *
+     * @param coordinates the coordinates for the context of the new scalar instance
+     * @return a new immutable scalar with the new context
+     * @throws NullPointerException if the given context is {@code null}
+     */
+    public final ImmutableScalar<V> withContext(Object... coordinates) {
+        return withContext(Position.of(coordinates));
+    }
 
-	@Override
-	public Position context() {
-		return this.context;
-	}
+    @Override
+    public Position context() {
+        return this.context;
+    }
 
-	@Override
-	public V value() {
-		return value;
-	}
+    @Override
+    public V value() {
+        return value;
+    }
 
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((context == null) ? 0 : context.hashCode());
-		result = prime * result + ((value == null) ? 0 : value.hashCode());
-		return result;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null) {
-			return false;
-		}
-		if (getClass() != obj.getClass()) {
-			return false;
-		}
-		ImmutableScalar<?> other = (ImmutableScalar<?>) obj;
-		if (context == null) {
-			if (other.context != null) {
-				return false;
-			}
-		} else if (!context.equals(other.context)) {
-			return false;
-		}
-		if (value == null) {
-			if (other.value != null) {
-				return false;
-			}
-		} else if (!value.equals(other.value)) {
-			return false;
-		}
-		return true;
-	}
-
-	@Override
-	public String toString() {
-		return "ImmutableScalar [value=" + value + ", context=" + context + "]";
-	}
+    @Override
+    public String toString() {
+        return "ImmutableScalar [value=" + value + ", context=" + context + "]";
+    }
 
 }

--- a/src/java/org/tensorics/core/tensor/ImmutableScalar.java
+++ b/src/java/org/tensorics/core/tensor/ImmutableScalar.java
@@ -62,6 +62,20 @@ public final class ImmutableScalar<V> extends AbstractScalar<V> implements Seria
 		return new ImmutableScalar<>(this.value, context);
 	}
 
+	/**
+	 * Returns a new scalar with the same value as this scalar, but the context
+	 * overridden by a position constructed from the given coordinates.
+	 * 
+	 * @param coordinates
+	 *            the coordinates for the context of the new scalar instance
+	 * @return a new immutable scalar with the new context
+	 * @throws NullPointerException
+	 *             if the given context is {@code null}
+	 */
+	public final ImmutableScalar<V> withContext(Object... coordinates) {
+		return withContext(Position.of(coordinates));
+	}
+
 	@Override
 	public Position context() {
 		return this.context;

--- a/src/java/org/tensorics/core/tensor/ImmutableScalar.java
+++ b/src/java/org/tensorics/core/tensor/ImmutableScalar.java
@@ -1,0 +1,118 @@
+package org.tensorics.core.tensor;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.Serializable;
+
+/**
+ * An immutable implementation of a scalar (a tensor with zero dimensions and
+ * exactly one value). To construct a simple scalar (with an empty context), use
+ * the {@link #of(Object)} method. An immutable scalar with a non-empty context
+ * can be created by chaining the {@link #of(Object)} method with the
+ * {@link #withContext(Position)} method.
+ * 
+ * @author kaifox
+ *
+ * @param <V>
+ *            the type of the value of the scalar
+ */
+public final class ImmutableScalar<V> extends AbstractScalar<V> implements Serializable {
+	private static final long serialVersionUID = 1L;
+
+	private final V value;
+	private final Position context;
+
+	/**
+	 * Should not be used directly. Use the factory method {@link #of(Object)}
+	 * 
+	 * @param value
+	 *            the value of the scalar
+	 * @param context
+	 *            the context of the new scalar
+	 */
+	private ImmutableScalar(V value, Position context) {
+		this.value = requireNonNull(value, "value must not be null");
+		this.context = requireNonNull(context, "context must not be null");
+	}
+
+	/**
+	 * Factory method for a scalar with an empty context.
+	 * 
+	 * @param value
+	 *            the value of the scalar
+	 * @return a new scalar with the given value
+	 * @throws NullPointerException
+	 *             if the given value is {@code null}
+	 */
+	public static <V> ImmutableScalar<V> of(V value) {
+		return new ImmutableScalar<V>(value, Position.empty());
+	}
+
+	/**
+	 * Returns a new scalar with the same value as this scalar, but the context
+	 * overridden by the given one.
+	 * 
+	 * @param context
+	 *            the context for the new scalar instance
+	 * @return a new immutable scalar with the new context
+	 * @throws NullPointerException
+	 *             if the given context is {@code null}
+	 */
+	public final ImmutableScalar<V> withContext(Position context) {
+		return new ImmutableScalar<>(this.value, context);
+	}
+
+	@Override
+	public Position context() {
+		return this.context;
+	}
+
+	@Override
+	public V value() {
+		return value;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((context == null) ? 0 : context.hashCode());
+		result = prime * result + ((value == null) ? 0 : value.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		ImmutableScalar<?> other = (ImmutableScalar<?>) obj;
+		if (context == null) {
+			if (other.context != null) {
+				return false;
+			}
+		} else if (!context.equals(other.context)) {
+			return false;
+		}
+		if (value == null) {
+			if (other.value != null) {
+				return false;
+			}
+		} else if (!value.equals(other.value)) {
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public String toString() {
+		return "ImmutableScalar [value=" + value + ", context=" + context + "]";
+	}
+
+}

--- a/src/java/org/tensorics/core/tensor/ImmutableTensor.java
+++ b/src/java/org/tensorics/core/tensor/ImmutableTensor.java
@@ -22,11 +22,14 @@
 
 package org.tensorics.core.tensor;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.Set;
 
 import org.tensorics.core.tensor.operations.TensorInternals;
@@ -37,180 +40,204 @@ import com.google.common.collect.ImmutableMultiset;
 /**
  * Default Implementation of {@link Tensor}.
  * <p>
- * By constraint of creation it holds a map of {@link Position} of certain type to values of type T, such that ALL
- * Positions contains the same number and type of coordinates. Number and type of coordinates can be accessed and
+ * By constraint of creation it holds a map of {@link Position} of certain type
+ * to values of type T, such that ALL Positions contains the same number and
+ * type of coordinates. Number and type of coordinates can be accessed and
  * explored via {@link Shape}.
  * <p>
- * There is a special type of Tensor that has ZERO dimensiality. Can be obtained via factory method.
+ * There is a special type of Tensor that has ZERO dimensiality. Can be obtained
+ * via factory method.
  * <p>
  * {@link ImmutableTensor} is immutable.
  * <p>
  * The toString() method does not print all the tensor entries.
  * 
  * @author agorzaws, kfuchsbe
- * @param <T> type of values in Tensor.
+ * @param <T>
+ *            type of values in Tensor.
  */
 public class ImmutableTensor<T> implements MappableTensor<T>, Serializable {
 
-    private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 1L;
 
-    private static final int TOSTRING_BUFFER_SIZE = 64;
-    private static final int POSITION_TO_DISPLAY = 10;
-    private final Map<Position, T> entries;
-    private final Shape shape; // NOSONAR
-    private final Position context; // NOSONAR
+	private static final int TOSTRING_BUFFER_SIZE = 64;
+	private static final int POSITION_TO_DISPLAY = 10;
+	private final Map<Position, T> entries;
+	private final Shape shape; // NOSONAR
+	private final Position context; // NOSONAR
 
-    /**
-     * Package-private constructor to be called from builder
-     * 
-     * @param builder to be used when {@link ImmutableTensor} is created.
-     */
-    ImmutableTensor(Builder<T> builder) {
-        this.entries = builder.createEntriesMap();
-        this.shape = Shape.viewOf(builder.dimensions(), this.entries.keySet());
-        this.context = builder.context();
-    }
+	/**
+	 * Package-private constructor to be called from builder
+	 * 
+	 * @param builder
+	 *            to be used when {@link ImmutableTensor} is created.
+	 */
+	ImmutableTensor(Builder<T> builder) {
+		this.entries = builder.createEntriesMap();
+		this.shape = Shape.viewOf(builder.dimensions(), this.entries.keySet());
+		this.context = builder.context();
+	}
 
-    /**
-     * Returns a builder for an {@link ImmutableTensor}. As argument it takes set of class of coordinates which
-     * represent the dimensions of the tensor.
-     * 
-     * @param dimensions a set of classes that can later be used as coordinates for the tensor entries.
-     * @return a builder for {@link ImmutableTensor}
-     * @param <T> type of values in Tensor.
-     */
-    public static final <T> Builder<T> builder(Set<Class<?>> dimensions) {
-        return new Builder<T>(dimensions);
-    }
+	/**
+	 * Returns a builder for an {@link ImmutableTensor}. As argument it takes
+	 * set of class of coordinates which represent the dimensions of the tensor.
+	 * 
+	 * @param dimensions
+	 *            a set of classes that can later be used as coordinates for the
+	 *            tensor entries.
+	 * @return a builder for {@link ImmutableTensor}
+	 * @param <T>
+	 *            type of values in Tensor.
+	 */
+	public static final <T> Builder<T> builder(Set<Class<?>> dimensions) {
+		return new Builder<T>(dimensions);
+	}
 
-    /**
-     * Returns a builder for an {@link ImmutableTensor}. The dimensions (classes of coordinates) of the future tensor
-     * have to be given as arguments here.
-     * 
-     * @param dimensions the dimensions of the tensor to create
-     * @return a builder for an immutable tensor
-     * @param <T> the type of values of the tensor
-     */
-    public static final <T> Builder<T> builder(Class<?>... dimensions) {
-        return builder(Coordinates.requireValidDimensions(ImmutableMultiset.copyOf(dimensions)));
-    }
+	/**
+	 * Returns a builder for an {@link ImmutableTensor}. The dimensions (classes
+	 * of coordinates) of the future tensor have to be given as arguments here.
+	 * 
+	 * @param dimensions
+	 *            the dimensions of the tensor to create
+	 * @return a builder for an immutable tensor
+	 * @param <T>
+	 *            the type of values of the tensor
+	 */
+	public static final <T> Builder<T> builder(Class<?>... dimensions) {
+		return builder(Coordinates.requireValidDimensions(ImmutableMultiset.copyOf(dimensions)));
+	}
 
-    /**
-     * Creates a tensor from the given map, where the map has to contain the positions as keys and the values as values.
-     * 
-     * @param dimensions the desired dimensions of the tensor. This has to be consistent with the position - keys in the
-     *            map.
-     * @param map the map from which to construct a tensor
-     * @return a new immutable tensor
-     */
-    public static final <T> Tensor<T> fromMap(Set<Class<?>> dimensions, Map<Position, T> map) {
-        Builder<T> builder = builder(dimensions);
-        builder.putAllMap(map);
-        return builder.build();
-    }
-    
-    /**
-     * Creates a tensor from the given map, where the map has to contain the positions as keys and the values as values.
-     * The dimensions of the tensors are automatically derived from the positions in the map. If they are inconsistent,
-     * this method throws; if the map is empty, an empty zero dimensional tensor is returned.
-     * 
-     * @param map the map from which to construct a tensor
-     * @return a new immutable tensor
-     * @deprecated use {@code fromMap(Set<? extends Class<?>> dimensions, Map<Position, T> map)}
-     */
-    @Deprecated
-    public static final <T> Tensor<T> fromMap(Map<Position, T> map) {
-        if (map.isEmpty()) {
-            return zeroDimensionalEmptyTensor();
-        } else {
-            return fromMap(extractDimensionsAndEnsureConsistency(map), map);
-        }
-    }
+	/**
+	 * Creates a tensor from the given map, where the map has to contain the
+	 * positions as keys and the values as values.
+	 * 
+	 * @param dimensions
+	 *            the desired dimensions of the tensor. This has to be
+	 *            consistent with the position - keys in the map.
+	 * @param map
+	 *            the map from which to construct a tensor
+	 * @return a new immutable tensor
+	 */
+	public static final <T> Tensor<T> fromMap(Set<Class<?>> dimensions, Map<Position, T> map) {
+		Builder<T> builder = builder(dimensions);
+		builder.putAllMap(map);
+		return builder.build();
+	}
 
-    private static <T> Set<Class<?>> extractDimensionsAndEnsureConsistency(Map<Position, T> data) {
-        Position anyPosition = data.keySet().iterator().next();
-        boolean sameDim = data.keySet().stream().map(Position::dimensionSet).allMatch(anyPosition::isConsistentWith);
-        if (!sameDim) {
-            throw new IllegalArgumentException(
-                    "For creating a Tensor from the map, all the positions must have the same dimensions");
-        }
-        return anyPosition.dimensionSet();
-    }
+	/**
+	 * Creates a tensor from the given map, where the map has to contain the
+	 * positions as keys and the values as values. The dimensions of the tensors
+	 * are automatically derived from the positions in the map. If they are
+	 * inconsistent, this method throws; if the map is empty, an empty zero
+	 * dimensional tensor is returned.
+	 * 
+	 * @param map
+	 *            the map from which to construct a tensor
+	 * @return a new immutable tensor
+	 * @deprecated use
+	 *             {@code fromMap(Set<? extends Class<?>> dimensions, Map<Position, T> map)}
+	 */
+	@Deprecated
+	public static final <T> Tensor<T> fromMap(Map<Position, T> map) {
+		if (map.isEmpty()) {
+			return zeroDimensionalEmptyTensor();
+		} else {
+			return fromMap(extractDimensionsAndEnsureConsistency(map), map);
+		}
+	}
 
-    private static <T> Tensor<T> zeroDimensionalEmptyTensor() {
-        Builder<T> builder = builder(Collections.<Class<?>> emptySet());
-        return builder.build();
-    }
+	private static <T> Set<Class<?>> extractDimensionsAndEnsureConsistency(Map<Position, T> data) {
+		Position anyPosition = data.keySet().iterator().next();
+		boolean sameDim = data.keySet().stream().map(Position::dimensionSet).allMatch(anyPosition::isConsistentWith);
+		if (!sameDim) {
+			throw new IllegalArgumentException(
+					"For creating a Tensor from the map, all the positions must have the same dimensions");
+		}
+		return anyPosition.dimensionSet();
+	}
 
-    /**
-     * Returns the builder that can create special tensor of dimension size equal ZERO.
-     * 
-     * @param value to be used.
-     * @return a builder for {@link ImmutableTensor}
-     * @param <T> type of values in Tensor.
-     */
-    public static final <T> Tensor<T> zeroDimensionalOf(T value) {
-        Builder<T> builder = builder(Collections.<Class<?>> emptySet());
-        builder.at(Position.empty()).put(value);
-        return builder.build();
-    }
+	private static <T> Tensor<T> zeroDimensionalEmptyTensor() {
+		Builder<T> builder = builder(Collections.<Class<?>>emptySet());
+		return builder.build();
+	}
 
-    /**
-     * Creates an immutable copy of the given tensor.
-     * 
-     * @param tensor the tensor whose element to copy
-     * @return new immutable Tensor
-     */
-    public static final <T> Tensor<T> copyOf(Tensor<T> tensor) {
-        Builder<T> builder = builder(tensor.shape().dimensionSet());
-        builder.putAllMap(TensorInternals.mapFrom(tensor));
-        builder.context(tensor.context());
-        return builder.build();
-    }
+	/**
+	 * Returns the builder that can create special tensor of dimension size
+	 * equal ZERO.
+	 * 
+	 * @param value
+	 *            to be used.
+	 * @return a builder for {@link ImmutableTensor}
+	 * @param <T>
+	 *            type of values in Tensor.
+	 */
+	public static final <T> Tensor<T> zeroDimensionalOf(T value) {
+		Builder<T> builder = builder(Collections.<Class<?>>emptySet());
+		builder.at(Position.empty()).put(value);
+		return builder.build();
+	}
 
-    /**
-     * Returns a builder for an {@link ImmutableTensor} which is initiliased with the given {@link ImmutableTensor}.
-     * 
-     * @param tensor a Tensor with which the {@link Builder} is initialized
-     * @return a {@link Builder} for an {@link ImmutableTensor}
-     * @param <T> type of values in Tensor.
-     */
-    public static <T> Builder<T> builderFrom(Tensor<T> tensor) {
-        Builder<T> builder = builder(tensor.shape().dimensionSet());
-        builder.putAllMap(TensorInternals.mapFrom(tensor));
-        return builder;
-    }
+	/**
+	 * Creates an immutable copy of the given tensor.
+	 * 
+	 * @param tensor
+	 *            the tensor whose element to copy
+	 * @return new immutable Tensor
+	 */
+	public static final <T> Tensor<T> copyOf(Tensor<T> tensor) {
+		Builder<T> builder = builder(tensor.shape().dimensionSet());
+		builder.putAllMap(TensorInternals.mapFrom(tensor));
+		builder.context(tensor.context());
+		return builder.build();
+	}
 
-    @Override
-    public T get(Position position) {
-        return findValueOrThrow(position);
-    }
+	/**
+	 * Returns a builder for an {@link ImmutableTensor} which is initiliased
+	 * with the given {@link ImmutableTensor}.
+	 * 
+	 * @param tensor
+	 *            a Tensor with which the {@link Builder} is initialized
+	 * @return a {@link Builder} for an {@link ImmutableTensor}
+	 * @param <T>
+	 *            type of values in Tensor.
+	 */
+	public static <T> Builder<T> builderFrom(Tensor<T> tensor) {
+		Builder<T> builder = builder(tensor.shape().dimensionSet());
+		builder.putAllMap(TensorInternals.mapFrom(tensor));
+		return builder;
+	}
 
-    @Override
-    public Position context() {
-        return this.context;
-    }
+	@Override
+	public T get(Position position) {
+		return findValueOrThrow(position);
+	}
 
-    @Override
-    public Map<Position, T> asMap() {
-        /*
-         * the internal map is already immutable and does not need to be copied
-         */
-        return entries;
-    }
+	@Override
+	public Position context() {
+		return this.context;
+	}
 
-    @Override
-    @SafeVarargs
-    public final T get(Object... coordinates) {
-        return get(Position.of(coordinates));
-    }
+	@Override
+	public Map<Position, T> asMap() {
+		/*
+		 * the internal map is already immutable and does not need to be copied
+		 */
+		return entries;
+	}
 
-    @Override
-    public Shape shape() {
-        return this.shape;
-    }
+	@Override
+	@SafeVarargs
+	public final T get(Object... coordinates) {
+		return get(Position.of(coordinates));
+	}
 
-    private T findValueOrThrow(Position position) {
+	@Override
+	public Shape shape() {
+		return this.shape;
+	}
+
+	private T findValueOrThrow(Position position) {
+    	requireNonNull(position, "position must not be null");
         Positions.areDimensionsConsistentWithCoordinates(shape.dimensionSet(), position);
         T entry = findEntryOrNull(position);
         if (entry == null) {
@@ -227,131 +254,132 @@ public class ImmutableTensor<T> implements MappableTensor<T>, Serializable {
         return entry;
     }
 
-    private T findEntryOrNull(Position position) {
-        return this.entries.get(position);
-    }
+	private T findEntryOrNull(Position position) {
+		return this.entries.get(position);
+	}
 
-    /**
-     * A builder for an immutable tensor.
-     * 
-     * @author kfuchsbe
-     * @param <S> the type of the values to be added
-     */
-    public static final class Builder<S> extends AbstractTensorBuilder<S> {
+	/**
+	 * A builder for an immutable tensor.
+	 * 
+	 * @author kfuchsbe
+	 * @param <S>
+	 *            the type of the values to be added
+	 */
+	public static final class Builder<S> extends AbstractTensorBuilder<S> {
 
-        private final Map<Position, S> entries = new HashMap<>();
+		private final Map<Position, S> entries = new HashMap<>();
 
-        Builder(Set<Class<?>> dimensions) {
-            super(dimensions);
-        }
+		Builder(Set<Class<?>> dimensions) {
+			super(dimensions);
+		}
 
-        /**
-         * Builds the entries map as an {@link ImmutableMap}.
-         * 
-         * @return
-         */
-        public Map<Position, S> createEntriesMap() {
-            return ImmutableMap.<Position, S> builder().putAll(entries).build();
-        }
+		/**
+		 * Builds the entries map as an {@link ImmutableMap}.
+		 * 
+		 * @return
+		 */
+		public Map<Position, S> createEntriesMap() {
+			return ImmutableMap.<Position, S>builder().putAll(entries).build();
+		}
 
-        /**
-         * Builds an {@link ImmutableTensor} from all elements put before.
-         * 
-         * @return an {@link ImmutableTensor}.
-         */
-        @Override
-        public ImmutableTensor<S> build() {
-            return new ImmutableTensor<S>(this);
-        }
+		/**
+		 * Builds an {@link ImmutableTensor} from all elements put before.
+		 * 
+		 * @return an {@link ImmutableTensor}.
+		 */
+		@Override
+		public ImmutableTensor<S> build() {
+			return new ImmutableTensor<S>(this);
+		}
 
-        @Override
-        protected void putItAt(S value, Position position) {
-            this.entries.put(position, value);
-        }
+		@Override
+		protected void putItAt(S value, Position position) {
+			this.entries.put(position, value);
+		}
 
-        @Override
-        public void putAllMap(Map<Position, S> newEntries) {
-            for (java.util.Map.Entry<Position, S> entry : newEntries.entrySet()) {
-                this.put(entry);
-            }
-        }
+		@Override
+		public void putAllMap(Map<Position, S> newEntries) {
+			for (java.util.Map.Entry<Position, S> entry : newEntries.entrySet()) {
+				this.put(entry);
+			}
+		}
 
-        @Override
-        public void removeAt(Position position) {
-            entries.remove(position);
-        }
+		@Override
+		public void removeAt(Position position) {
+			entries.remove(position);
+		}
 
-        @Override
-        public void put(java.util.Map.Entry<Position, S> entry) {
-            this.putAt(entry.getValue(), entry.getKey());
-        }
+		@Override
+		public void put(java.util.Map.Entry<Position, S> entry) {
+			this.putAt(entry.getValue(), entry.getKey());
+		}
 
-        @Override
-        public void putAll(Tensor<S> tensor) {
-            this.putAllAt(tensor);
-        }
+		@Override
+		public void putAll(Tensor<S> tensor) {
+			this.putAllAt(tensor);
+		}
 
-    }
+	}
 
-    /**
-     * When printing the tensor content output is automatically not larger then N ant the beginning and N at the end of
-     * the Tensor entries.
-     */
-    @Override
-    public String toString() {
-        StringBuffer buffer = new StringBuffer(TOSTRING_BUFFER_SIZE);
-        int totalSize = this.shape.positionSet().size();
-        int index = 1;
-        for (Position position : this.shape.positionSet()) {
-            if (index < POSITION_TO_DISPLAY || index > totalSize - POSITION_TO_DISPLAY) {
-                buffer.append(position + "=(" + get(position) + "), ");
-            } else if (index == POSITION_TO_DISPLAY) {
-                buffer.append(".. [" + (totalSize - 2 * POSITION_TO_DISPLAY) + " skipped entries] .. , ");
-            }
-            index++;
-        }
-        if (buffer.length() > 1) {
-            buffer.setLength(buffer.length() - 2);
-        }
-        return Coordinates.dimensionsWithoutClassPath(this) + ", Content:{" + buffer + "}";
-    }
+	/**
+	 * When printing the tensor content output is automatically not larger then
+	 * N ant the beginning and N at the end of the Tensor entries.
+	 */
+	@Override
+	public String toString() {
+		StringBuffer buffer = new StringBuffer(TOSTRING_BUFFER_SIZE);
+		int totalSize = this.shape.positionSet().size();
+		int index = 1;
+		for (Position position : this.shape.positionSet()) {
+			if (index < POSITION_TO_DISPLAY || index > totalSize - POSITION_TO_DISPLAY) {
+				buffer.append(position + "=(" + get(position) + "), ");
+			} else if (index == POSITION_TO_DISPLAY) {
+				buffer.append(".. [" + (totalSize - 2 * POSITION_TO_DISPLAY) + " skipped entries] .. , ");
+			}
+			index++;
+		}
+		if (buffer.length() > 1) {
+			buffer.setLength(buffer.length() - 2);
+		}
+		return Coordinates.dimensionsWithoutClassPath(this) + ", Content:{" + buffer + "}";
+	}
 
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((context == null) ? 0 : context.hashCode());
-        result = prime * result + ((entries == null) ? 0 : entries.hashCode());
-        result = prime * result + ((shape == null) ? 0 : shape.hashCode());
-        return result;
-    }
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((context == null) ? 0 : context.hashCode());
+		result = prime * result + ((entries == null) ? 0 : entries.hashCode());
+		result = prime * result + ((shape == null) ? 0 : shape.hashCode());
+		return result;
+	}
 
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj)
-            return true;
-        if (obj == null)
-            return false;
-        if (getClass() != obj.getClass())
-            return false;
-        @SuppressWarnings("rawtypes")
-        ImmutableTensor other = (ImmutableTensor) obj;
-        if (context == null) {
-            if (other.context != null)
-                return false;
-        } else if (!context.equals(other.context))
-            return false;
-        if (entries == null) {
-            if (other.entries != null)
-                return false;
-        } else if (!entries.equals(other.entries))
-            return false;
-        if (shape == null) {
-            if (other.shape != null)
-                return false;
-        } else if (!shape.equals(other.shape))
-            return false;
-        return true;
-    }
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		@SuppressWarnings("rawtypes")
+		ImmutableTensor other = (ImmutableTensor) obj;
+		if (context == null) {
+			if (other.context != null)
+				return false;
+		} else if (!context.equals(other.context))
+			return false;
+		if (entries == null) {
+			if (other.entries != null)
+				return false;
+		} else if (!entries.equals(other.entries))
+			return false;
+		if (shape == null) {
+			if (other.shape != null)
+				return false;
+		} else if (!shape.equals(other.shape))
+			return false;
+		return true;
+	}
 
 }

--- a/src/java/org/tensorics/core/tensor/ImmutableTensor.java
+++ b/src/java/org/tensorics/core/tensor/ImmutableTensor.java
@@ -29,7 +29,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.Set;
 
 import org.tensorics.core.tensor.operations.TensorInternals;
@@ -170,7 +169,9 @@ public class ImmutableTensor<T> implements MappableTensor<T>, Serializable {
 	 * @return a builder for {@link ImmutableTensor}
 	 * @param <T>
 	 *            type of values in Tensor.
+	 * @deprecated use {@link ImmutableScalar} instead
 	 */
+	@Deprecated
 	public static final <T> Tensor<T> zeroDimensionalOf(T value) {
 		Builder<T> builder = builder(Collections.<Class<?>>emptySet());
 		builder.at(Position.empty()).put(value);

--- a/src/java/org/tensorics/core/tensor/ImmutableTensor.java
+++ b/src/java/org/tensorics/core/tensor/ImmutableTensor.java
@@ -2,7 +2,7 @@
 /*******************************************************************************
 *
 * This file is part of tensorics.
-* 
+*
 * Copyright (c) 2008-2011, CERN. All rights reserved.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
-* 
+*
 ******************************************************************************/
 // @formatter:on
 
@@ -39,206 +39,183 @@ import com.google.common.collect.ImmutableMultiset;
 /**
  * Default Implementation of {@link Tensor}.
  * <p>
- * By constraint of creation it holds a map of {@link Position} of certain type
- * to values of type T, such that ALL Positions contains the same number and
- * type of coordinates. Number and type of coordinates can be accessed and
+ * By constraint of creation it holds a map of {@link Position} of certain type to values of type T, such that ALL
+ * Positions contains the same number and type of coordinates. Number and type of coordinates can be accessed and
  * explored via {@link Shape}.
  * <p>
- * There is a special type of Tensor that has ZERO dimensiality. Can be obtained
- * via factory method.
+ * There is a special type of Tensor that has ZERO dimensiality. Can be obtained via factory method.
  * <p>
  * {@link ImmutableTensor} is immutable.
  * <p>
  * The toString() method does not print all the tensor entries.
- * 
+ *
  * @author agorzaws, kfuchsbe
- * @param <T>
- *            type of values in Tensor.
+ * @param <T> type of values in Tensor.
  */
-public class ImmutableTensor<T> implements MappableTensor<T>, Serializable {
+public class ImmutableTensor<T> extends AbstractTensor<T>implements MappableTensor<T>, Serializable {
 
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-	private static final int TOSTRING_BUFFER_SIZE = 64;
-	private static final int POSITION_TO_DISPLAY = 10;
-	private final Map<Position, T> entries;
-	private final Shape shape; // NOSONAR
-	private final Position context; // NOSONAR
+    private static final int TOSTRING_BUFFER_SIZE = 64;
+    private static final int POSITION_TO_DISPLAY = 10;
+    private final Map<Position, T> entries;
+    private final Shape shape; // NOSONAR
+    private final Position context; // NOSONAR
 
-	/**
-	 * Package-private constructor to be called from builder
-	 * 
-	 * @param builder
-	 *            to be used when {@link ImmutableTensor} is created.
-	 */
-	ImmutableTensor(Builder<T> builder) {
-		this.entries = builder.createEntriesMap();
-		this.shape = Shape.viewOf(builder.dimensions(), this.entries.keySet());
-		this.context = builder.context();
-	}
+    /**
+     * Package-private constructor to be called from builder
+     *
+     * @param builder to be used when {@link ImmutableTensor} is created.
+     */
+    ImmutableTensor(Builder<T> builder) {
+        this.entries = builder.createEntriesMap();
+        this.shape = Shape.viewOf(builder.dimensions(), this.entries.keySet());
+        this.context = builder.context();
+    }
 
-	/**
-	 * Returns a builder for an {@link ImmutableTensor}. As argument it takes
-	 * set of class of coordinates which represent the dimensions of the tensor.
-	 * 
-	 * @param dimensions
-	 *            a set of classes that can later be used as coordinates for the
-	 *            tensor entries.
-	 * @return a builder for {@link ImmutableTensor}
-	 * @param <T>
-	 *            type of values in Tensor.
-	 */
-	public static final <T> Builder<T> builder(Set<Class<?>> dimensions) {
-		return new Builder<T>(dimensions);
-	}
+    /**
+     * Returns a builder for an {@link ImmutableTensor}. As argument it takes set of class of coordinates which
+     * represent the dimensions of the tensor.
+     *
+     * @param dimensions a set of classes that can later be used as coordinates for the tensor entries.
+     * @return a builder for {@link ImmutableTensor}
+     * @param <T> type of values in Tensor.
+     */
+    public static final <T> Builder<T> builder(Set<Class<?>> dimensions) {
+        return new Builder<T>(dimensions);
+    }
 
-	/**
-	 * Returns a builder for an {@link ImmutableTensor}. The dimensions (classes
-	 * of coordinates) of the future tensor have to be given as arguments here.
-	 * 
-	 * @param dimensions
-	 *            the dimensions of the tensor to create
-	 * @return a builder for an immutable tensor
-	 * @param <T>
-	 *            the type of values of the tensor
-	 */
-	public static final <T> Builder<T> builder(Class<?>... dimensions) {
-		return builder(Coordinates.requireValidDimensions(ImmutableMultiset.copyOf(dimensions)));
-	}
+    /**
+     * Returns a builder for an {@link ImmutableTensor}. The dimensions (classes of coordinates) of the future tensor
+     * have to be given as arguments here.
+     *
+     * @param dimensions the dimensions of the tensor to create
+     * @return a builder for an immutable tensor
+     * @param <T> the type of values of the tensor
+     */
+    public static final <T> Builder<T> builder(Class<?>... dimensions) {
+        return builder(Coordinates.requireValidDimensions(ImmutableMultiset.copyOf(dimensions)));
+    }
 
-	/**
-	 * Creates a tensor from the given map, where the map has to contain the
-	 * positions as keys and the values as values.
-	 * 
-	 * @param dimensions
-	 *            the desired dimensions of the tensor. This has to be
-	 *            consistent with the position - keys in the map.
-	 * @param map
-	 *            the map from which to construct a tensor
-	 * @return a new immutable tensor
-	 */
-	public static final <T> Tensor<T> fromMap(Set<Class<?>> dimensions, Map<Position, T> map) {
-		Builder<T> builder = builder(dimensions);
-		builder.putAllMap(map);
-		return builder.build();
-	}
+    /**
+     * Creates a tensor from the given map, where the map has to contain the positions as keys and the values as values.
+     *
+     * @param dimensions the desired dimensions of the tensor. This has to be consistent with the position - keys in the
+     *            map.
+     * @param map the map from which to construct a tensor
+     * @return a new immutable tensor
+     */
+    public static final <T> Tensor<T> fromMap(Set<Class<?>> dimensions, Map<Position, T> map) {
+        Builder<T> builder = builder(dimensions);
+        builder.putAllMap(map);
+        return builder.build();
+    }
 
-	/**
-	 * Creates a tensor from the given map, where the map has to contain the
-	 * positions as keys and the values as values. The dimensions of the tensors
-	 * are automatically derived from the positions in the map. If they are
-	 * inconsistent, this method throws; if the map is empty, an empty zero
-	 * dimensional tensor is returned.
-	 * 
-	 * @param map
-	 *            the map from which to construct a tensor
-	 * @return a new immutable tensor
-	 * @deprecated use
-	 *             {@code fromMap(Set<? extends Class<?>> dimensions, Map<Position, T> map)}
-	 */
-	@Deprecated
-	public static final <T> Tensor<T> fromMap(Map<Position, T> map) {
-		if (map.isEmpty()) {
-			return zeroDimensionalEmptyTensor();
-		} else {
-			return fromMap(extractDimensionsAndEnsureConsistency(map), map);
-		}
-	}
+    /**
+     * Creates a tensor from the given map, where the map has to contain the positions as keys and the values as values.
+     * The dimensions of the tensors are automatically derived from the positions in the map. If they are inconsistent,
+     * this method throws; if the map is empty, an empty zero dimensional tensor is returned.
+     *
+     * @param map the map from which to construct a tensor
+     * @return a new immutable tensor
+     * @deprecated use {@code fromMap(Set<? extends Class<?>> dimensions, Map<Position, T> map)}
+     */
+    @Deprecated
+    public static final <T> Tensor<T> fromMap(Map<Position, T> map) {
+        if (map.isEmpty()) {
+            return zeroDimensionalEmptyTensor();
+        } else {
+            return fromMap(extractDimensionsAndEnsureConsistency(map), map);
+        }
+    }
 
-	private static <T> Set<Class<?>> extractDimensionsAndEnsureConsistency(Map<Position, T> data) {
-		Position anyPosition = data.keySet().iterator().next();
-		boolean sameDim = data.keySet().stream().map(Position::dimensionSet).allMatch(anyPosition::isConsistentWith);
-		if (!sameDim) {
-			throw new IllegalArgumentException(
-					"For creating a Tensor from the map, all the positions must have the same dimensions");
-		}
-		return anyPosition.dimensionSet();
-	}
+    private static <T> Set<Class<?>> extractDimensionsAndEnsureConsistency(Map<Position, T> data) {
+        Position anyPosition = data.keySet().iterator().next();
+        boolean sameDim = data.keySet().stream().map(Position::dimensionSet).allMatch(anyPosition::isConsistentWith);
+        if (!sameDim) {
+            throw new IllegalArgumentException(
+                    "For creating a Tensor from the map, all the positions must have the same dimensions");
+        }
+        return anyPosition.dimensionSet();
+    }
 
-	private static <T> Tensor<T> zeroDimensionalEmptyTensor() {
-		Builder<T> builder = builder(Collections.<Class<?>>emptySet());
-		return builder.build();
-	}
+    private static <T> Tensor<T> zeroDimensionalEmptyTensor() {
+        Builder<T> builder = builder(Collections.<Class<?>> emptySet());
+        return builder.build();
+    }
 
-	/**
-	 * Returns the builder that can create special tensor of dimension size
-	 * equal ZERO.
-	 * 
-	 * @param value
-	 *            to be used.
-	 * @return a builder for {@link ImmutableTensor}
-	 * @param <T>
-	 *            type of values in Tensor.
-	 * @deprecated use {@link ImmutableScalar} instead
-	 */
-	@Deprecated
-	public static final <T> Tensor<T> zeroDimensionalOf(T value) {
-		Builder<T> builder = builder(Collections.<Class<?>>emptySet());
-		builder.at(Position.empty()).put(value);
-		return builder.build();
-	}
+    /**
+     * Returns the builder that can create special tensor of dimension size equal ZERO.
+     *
+     * @param value to be used.
+     * @return a builder for {@link ImmutableTensor}
+     * @param <T> type of values in Tensor.
+     * @deprecated use {@link ImmutableScalar} instead
+     */
+    @Deprecated
+    public static final <T> Tensor<T> zeroDimensionalOf(T value) {
+        Builder<T> builder = builder(Collections.<Class<?>> emptySet());
+        builder.at(Position.empty()).put(value);
+        return builder.build();
+    }
 
-	/**
-	 * Creates an immutable copy of the given tensor.
-	 * 
-	 * @param tensor
-	 *            the tensor whose element to copy
-	 * @return new immutable Tensor
-	 */
-	public static final <T> Tensor<T> copyOf(Tensor<T> tensor) {
-		Builder<T> builder = builder(tensor.shape().dimensionSet());
-		builder.putAllMap(TensorInternals.mapFrom(tensor));
-		builder.context(tensor.context());
-		return builder.build();
-	}
+    /**
+     * Creates an immutable copy of the given tensor.
+     *
+     * @param tensor the tensor whose element to copy
+     * @return new immutable Tensor
+     */
+    public static final <T> Tensor<T> copyOf(Tensor<T> tensor) {
+        Builder<T> builder = builder(tensor.shape().dimensionSet());
+        builder.putAllMap(TensorInternals.mapFrom(tensor));
+        builder.context(tensor.context());
+        return builder.build();
+    }
 
-	/**
-	 * Returns a builder for an {@link ImmutableTensor} which is initiliased
-	 * with the given {@link ImmutableTensor}.
-	 * 
-	 * @param tensor
-	 *            a Tensor with which the {@link Builder} is initialized
-	 * @return a {@link Builder} for an {@link ImmutableTensor}
-	 * @param <T>
-	 *            type of values in Tensor.
-	 */
-	public static <T> Builder<T> builderFrom(Tensor<T> tensor) {
-		Builder<T> builder = builder(tensor.shape().dimensionSet());
-		builder.putAllMap(TensorInternals.mapFrom(tensor));
-		return builder;
-	}
+    /**
+     * Returns a builder for an {@link ImmutableTensor} which is initiliased with the given {@link ImmutableTensor}.
+     *
+     * @param tensor a Tensor with which the {@link Builder} is initialized
+     * @return a {@link Builder} for an {@link ImmutableTensor}
+     * @param <T> type of values in Tensor.
+     */
+    public static <T> Builder<T> builderFrom(Tensor<T> tensor) {
+        Builder<T> builder = builder(tensor.shape().dimensionSet());
+        builder.putAllMap(TensorInternals.mapFrom(tensor));
+        return builder;
+    }
 
-	@Override
-	public T get(Position position) {
-		return findValueOrThrow(position);
-	}
+    @Override
+    public T get(Position position) {
+        return findValueOrThrow(position);
+    }
 
-	@Override
-	public Position context() {
-		return this.context;
-	}
+    @Override
+    public Position context() {
+        return this.context;
+    }
 
-	@Override
-	public Map<Position, T> asMap() {
-		/*
-		 * the internal map is already immutable and does not need to be copied
-		 */
-		return entries;
-	}
+    @Override
+    public Map<Position, T> asMap() {
+        /*
+         * the internal map is already immutable and does not need to be copied
+         */
+        return entries;
+    }
 
-	@Override
-	@SafeVarargs
-	public final T get(Object... coordinates) {
-		return get(Position.of(coordinates));
-	}
+    @Override
+    @SafeVarargs
+    public final T get(Object... coordinates) {
+        return get(Position.of(coordinates));
+    }
 
-	@Override
-	public Shape shape() {
-		return this.shape;
-	}
+    @Override
+    public Shape shape() {
+        return this.shape;
+    }
 
-	private T findValueOrThrow(Position position) {
-    	requireNonNull(position, "position must not be null");
+    private T findValueOrThrow(Position position) {
+        requireNonNull(position, "position must not be null");
         Positions.areDimensionsConsistentWithCoordinates(shape.dimensionSet(), position);
         T entry = findEntryOrNull(position);
         if (entry == null) {
@@ -255,132 +232,93 @@ public class ImmutableTensor<T> implements MappableTensor<T>, Serializable {
         return entry;
     }
 
-	private T findEntryOrNull(Position position) {
-		return this.entries.get(position);
-	}
+    private T findEntryOrNull(Position position) {
+        return this.entries.get(position);
+    }
 
-	/**
-	 * A builder for an immutable tensor.
-	 * 
-	 * @author kfuchsbe
-	 * @param <S>
-	 *            the type of the values to be added
-	 */
-	public static final class Builder<S> extends AbstractTensorBuilder<S> {
+    /**
+     * A builder for an immutable tensor.
+     *
+     * @author kfuchsbe
+     * @param <S> the type of the values to be added
+     */
+    public static final class Builder<S> extends AbstractTensorBuilder<S> {
 
-		private final Map<Position, S> entries = new HashMap<>();
+        private final Map<Position, S> entries = new HashMap<>();
 
-		Builder(Set<Class<?>> dimensions) {
-			super(dimensions);
-		}
+        Builder(Set<Class<?>> dimensions) {
+            super(dimensions);
+        }
 
-		/**
-		 * Builds the entries map as an {@link ImmutableMap}.
-		 * 
-		 * @return
-		 */
-		public Map<Position, S> createEntriesMap() {
-			return ImmutableMap.<Position, S>builder().putAll(entries).build();
-		}
+        /**
+         * Builds the entries map as an {@link ImmutableMap}.
+         *
+         * @return
+         */
+        public Map<Position, S> createEntriesMap() {
+            return ImmutableMap.<Position, S> builder().putAll(entries).build();
+        }
 
-		/**
-		 * Builds an {@link ImmutableTensor} from all elements put before.
-		 * 
-		 * @return an {@link ImmutableTensor}.
-		 */
-		@Override
-		public ImmutableTensor<S> build() {
-			return new ImmutableTensor<S>(this);
-		}
+        /**
+         * Builds an {@link ImmutableTensor} from all elements put before.
+         *
+         * @return an {@link ImmutableTensor}.
+         */
+        @Override
+        public ImmutableTensor<S> build() {
+            return new ImmutableTensor<S>(this);
+        }
 
-		@Override
-		protected void putItAt(S value, Position position) {
-			this.entries.put(position, value);
-		}
+        @Override
+        protected void putItAt(S value, Position position) {
+            this.entries.put(position, value);
+        }
 
-		@Override
-		public void putAllMap(Map<Position, S> newEntries) {
-			for (java.util.Map.Entry<Position, S> entry : newEntries.entrySet()) {
-				this.put(entry);
-			}
-		}
+        @Override
+        public void putAllMap(Map<Position, S> newEntries) {
+            for (java.util.Map.Entry<Position, S> entry : newEntries.entrySet()) {
+                this.put(entry);
+            }
+        }
 
-		@Override
-		public void removeAt(Position position) {
-			entries.remove(position);
-		}
+        @Override
+        public void removeAt(Position position) {
+            entries.remove(position);
+        }
 
-		@Override
-		public void put(java.util.Map.Entry<Position, S> entry) {
-			this.putAt(entry.getValue(), entry.getKey());
-		}
+        @Override
+        public void put(java.util.Map.Entry<Position, S> entry) {
+            this.putAt(entry.getValue(), entry.getKey());
+        }
 
-		@Override
-		public void putAll(Tensor<S> tensor) {
-			this.putAllAt(tensor);
-		}
+        @Override
+        public void putAll(Tensor<S> tensor) {
+            this.putAllAt(tensor);
+        }
 
-	}
+    }
 
-	/**
-	 * When printing the tensor content output is automatically not larger then
-	 * N ant the beginning and N at the end of the Tensor entries.
-	 */
-	@Override
-	public String toString() {
-		StringBuffer buffer = new StringBuffer(TOSTRING_BUFFER_SIZE);
-		int totalSize = this.shape.positionSet().size();
-		int index = 1;
-		for (Position position : this.shape.positionSet()) {
-			if (index < POSITION_TO_DISPLAY || index > totalSize - POSITION_TO_DISPLAY) {
-				buffer.append(position + "=(" + get(position) + "), ");
-			} else if (index == POSITION_TO_DISPLAY) {
-				buffer.append(".. [" + (totalSize - 2 * POSITION_TO_DISPLAY) + " skipped entries] .. , ");
-			}
-			index++;
-		}
-		if (buffer.length() > 1) {
-			buffer.setLength(buffer.length() - 2);
-		}
-		return Coordinates.dimensionsWithoutClassPath(this) + ", Content:{" + buffer + "}";
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((context == null) ? 0 : context.hashCode());
-		result = prime * result + ((entries == null) ? 0 : entries.hashCode());
-		result = prime * result + ((shape == null) ? 0 : shape.hashCode());
-		return result;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		@SuppressWarnings("rawtypes")
-		ImmutableTensor other = (ImmutableTensor) obj;
-		if (context == null) {
-			if (other.context != null)
-				return false;
-		} else if (!context.equals(other.context))
-			return false;
-		if (entries == null) {
-			if (other.entries != null)
-				return false;
-		} else if (!entries.equals(other.entries))
-			return false;
-		if (shape == null) {
-			if (other.shape != null)
-				return false;
-		} else if (!shape.equals(other.shape))
-			return false;
-		return true;
-	}
+    /**
+     * When printing the tensor content output is automatically not larger then N ant the beginning and N at the end of
+     * the Tensor entries.
+     */
+    @Override
+    public String toString() {
+        StringBuffer buffer = new StringBuffer(TOSTRING_BUFFER_SIZE);
+        int totalSize = this.shape.positionSet().size();
+        int index = 1;
+        for (Position position : this.shape.positionSet()) {
+            if (index < POSITION_TO_DISPLAY || index > totalSize - POSITION_TO_DISPLAY) {
+                buffer.append(position + "=(" + get(position) + "), ");
+            } else if (index == POSITION_TO_DISPLAY) {
+                buffer.append(".. [" + (totalSize - 2 * POSITION_TO_DISPLAY) + " skipped entries] .. , ");
+            }
+            index++;
+        }
+        if (buffer.length() > 1) {
+            buffer.setLength(buffer.length() - 2);
+        }
+        return Coordinates.dimensionsWithoutClassPath(this) + ", Content:{" + buffer + "}";
+    }
 
 }

--- a/src/java/org/tensorics/core/tensor/MappableTensor.java
+++ b/src/java/org/tensorics/core/tensor/MappableTensor.java
@@ -3,38 +3,30 @@ package org.tensorics.core.tensor;
 import java.util.Map;
 
 /**
- * Enhances the tensor interface by a method to view the tensor as a map from
- * position to values. This interface is intended to be used by utility methods
- * in order to avoid unnecessary calls.
+ * Enhances the tensor interface by a method to view the tensor as a map from position to values. This interface is
+ * intended to be used by utility methods in order to avoid unnecessary calls.
  * 
  * @author kaifox
- *
- * @param <V>
- *            the type of the values of the tensors
+ * @param <V> the type of the values of the tensors
  */
 public interface MappableTensor<V> extends Tensor<V> {
 
-	/**
-	 * By implementing this method, a tensor can provide an efficient way to
-	 * convert the tensor to a map from position to values. Implementing
-	 * instances must follow the following contract:
-	 * <ul>
-	 * <li>this method must not return {@code null}
-	 * <li>It is recommended to return either a copy or an immutable map.
-	 * Despite clients are not supposed to manipulate the returned maps, it
-	 * cannot be guaranteed and this could lead to unexpected results.
-	 * </ul>
-	 * Usually, clients will not use this method directly, but should use
-	 * {@link org.tensorics.core.tensor.operations.TensorInternals#mapFrom(Tensor)}
-	 * (internal clients) or
-	 * {@link org.tensorics.core.lang.Tensorics#mapFrom(Tensor)} (external
-	 * clients)
-	 * 
-	 * @see org.tensorics.core.tensor.operations.TensorInternals#mapFrom(Tensor)
-	 * @see org.tensorics.core.lang.Tensorics#mapFrom(Tensor)
-	 * @return a (preferrably immutable) map representing the content of the
-	 *         tensor
-	 */
-	public Map<Position, V> asMap();
+    /**
+     * By implementing this method, a tensor can provide an efficient way to convert the tensor to a map from position
+     * to values. Implementing instances must follow the following contract:
+     * <ul>
+     * <li>this method must not return {@code null}
+     * <li>It is recommended to return either a copy or an immutable map. Despite clients are not supposed to manipulate
+     * the returned maps, it cannot be guaranteed and this could lead to unexpected results.
+     * </ul>
+     * Usually, clients will not use this method directly, but should use
+     * {@link org.tensorics.core.tensor.operations.TensorInternals#mapFrom(Tensor)} (internal clients) or
+     * {@link org.tensorics.core.lang.Tensorics#mapFrom(Tensor)} (external clients)
+     * 
+     * @see org.tensorics.core.tensor.operations.TensorInternals#mapFrom(Tensor)
+     * @see org.tensorics.core.lang.Tensorics#mapFrom(Tensor)
+     * @return a (preferrably immutable) map representing the content of the tensor
+     */
+    public Map<Position, V> asMap();
 
 }

--- a/src/java/org/tensorics/core/tensor/Position.java
+++ b/src/java/org/tensorics/core/tensor/Position.java
@@ -22,6 +22,7 @@
 
 package org.tensorics.core.tensor;
 
+import static java.util.Objects.requireNonNull;
 import static org.tensorics.core.tensor.Coordinates.requireValidCoordinates;
 
 import java.io.Serializable;
@@ -78,6 +79,7 @@ public final class Position implements Serializable {
 
 	@SafeVarargs
 	public static Position of(Object... coordinates) {
+		requireNonNull(coordinates, "coordinates must not be null");
 		return createFrom(requireValidCoordinates(ImmutableMultiset.copyOf(coordinates)));
 	}
 
@@ -125,6 +127,11 @@ public final class Position implements Serializable {
 	}
 
 	@Override
+	public String toString() {
+		return "Position [coordinates=" + coordinates + "]";
+	}
+
+	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
@@ -140,9 +147,7 @@ public final class Position implements Serializable {
 		if (obj == null) {
 			return false;
 		}
-		if (!(obj instanceof Position)) { // TODO: this should be changed again
-											// to standard of getClass() after
-											// context refactoring
+		if (getClass() != obj.getClass()) {
 			return false;
 		}
 		Position other = (Position) obj;
@@ -154,11 +159,6 @@ public final class Position implements Serializable {
 			return false;
 		}
 		return true;
-	}
-
-	@Override
-	public String toString() {
-		return "Position [coordinates=" + coordinates + "]";
 	}
 
 }

--- a/src/java/org/tensorics/core/tensor/Position.java
+++ b/src/java/org/tensorics/core/tensor/Position.java
@@ -36,129 +36,123 @@ import com.google.common.collect.Interner;
 import com.google.common.collect.Interners;
 
 /**
- * Defines the position of a value within a tensor in the N-dimensional
- * coordinate space.
+ * Defines the position of a value within a tensor in the N-dimensional coordinate space.
  * 
  * @author agorzaws
  */
 public final class Position implements Serializable {
 
-	private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
-	private static final Interner<Position> INTERNER = Interners.newWeakInterner();
+    private static final Interner<Position> INTERNER = Interners.newWeakInterner();
 
-	/*
-	 * NOTE: This has to be after the cachedPositions initialization, because
-	 * the 'of' method uses it!
-	 */
-	private static final Position EMPTY_POSITION = Position.createFrom(Collections.emptySet());
+    /*
+     * NOTE: This has to be after the cachedPositions initialization, because the 'of' method uses it!
+     */
+    private static final Position EMPTY_POSITION = Position.createFrom(Collections.emptySet());
 
-	private ImmutableSet<?> coordinates;
+    private ImmutableSet<?> coordinates;
 
-	protected Position(Set<?> coordinates) {
-		this.coordinates = ImmutableSet.copyOf(coordinates);
-		for (Object oneCoordinate : coordinates) {
-			if (oneCoordinate instanceof Position) {
-				throw new IllegalArgumentException("A position is contained in the collection of coordinates."
-						+ "This is most-probably a programming mistake and therefore not allowed.");
-			}
-		}
-	}
+    protected Position(Set<?> coordinates) {
+        this.coordinates = ImmutableSet.copyOf(coordinates);
+        for (Object oneCoordinate : coordinates) {
+            if (oneCoordinate instanceof Position) {
+                throw new IllegalArgumentException("A position is contained in the collection of coordinates."
+                        + "This is most-probably a programming mistake and therefore not allowed.");
+            }
+        }
+    }
 
-	public static Position of(Set<?> coordinates) {
-		return createFrom(requireValidCoordinates(coordinates));
-	}
+    public static Position of(Set<?> coordinates) {
+        return createFrom(requireValidCoordinates(coordinates));
+    }
 
-	private static Position createFrom(Set<?> coordinates) {
-		return INTERNER.intern(new Position(coordinates));
-	}
+    private static Position createFrom(Set<?> coordinates) {
+        return INTERNER.intern(new Position(coordinates));
+    }
 
-	public static Position empty() {
-		return EMPTY_POSITION;
-	}
+    public static Position empty() {
+        return EMPTY_POSITION;
+    }
 
-	@SafeVarargs
-	public static Position of(Object... coordinates) {
-		requireNonNull(coordinates, "coordinates must not be null");
-		return createFrom(requireValidCoordinates(ImmutableMultiset.copyOf(coordinates)));
-	}
+    @SafeVarargs
+    public static Position of(Object... coordinates) {
+        requireNonNull(coordinates, "coordinates must not be null");
+        return createFrom(requireValidCoordinates(ImmutableMultiset.copyOf(coordinates)));
+    }
 
-	/**
-	 * @deprecated use coordinates() instead
-	 */
-	@Deprecated
-	public Set<?> getCoordinates() {
-		return coordinates();
-	}
+    /**
+     * @deprecated use coordinates() instead
+     */
+    @Deprecated
+    public Set<?> getCoordinates() {
+        return coordinates();
+    }
 
-	public <CS> CS coordinateFor(Class<CS> dimension) {
-		return Coordinates.firstCoordinateOfTyp(coordinates, dimension);
-	}
+    public <CS> CS coordinateFor(Class<CS> dimension) {
+        return Coordinates.firstCoordinateOfTyp(coordinates, dimension);
+    }
 
-	public Set<?> coordinates() {
-		return coordinates;
-	}
+    public Set<?> coordinates() {
+        return coordinates;
+    }
 
-	/**
-	 * Retrieves the dimensions of this position (i.e. the type of the
-	 * containing coordinates).
-	 * <p>
-	 * <b>NOTE!</b> These dimensions may differ from the ones kept in the parent
-	 * tensor!.
-	 * 
-	 * @return the types of the coordinates
-	 */
-	public Set<Class<?>> dimensionSet() {
-		return Coordinates.getDimensionsFrom(coordinates);
-	}
+    /**
+     * Retrieves the dimensions of this position (i.e. the type of the containing coordinates).
+     * <p>
+     * <b>NOTE!</b> These dimensions may differ from the ones kept in the parent tensor!.
+     * 
+     * @return the types of the coordinates
+     */
+    public Set<Class<?>> dimensionSet() {
+        return Coordinates.getDimensionsFrom(coordinates);
+    }
 
-	/**
-	 * Checks if the position is consistent with the given dimensions.
-	 * Conformity means that the position contains exactly one coordinate for
-	 * each dimension in the given set of dimensions (classes of coordinates).
-	 * 
-	 * @param dimensions
-	 *            the dimensions for which conformity has to be checked.
-	 * @return {@code true} if the position is conform, {@code false} if not.
-	 */
-	public boolean isConsistentWith(Set<Class<?>> dimensions) {
-		Preconditions.checkArgument(dimensions != null, "Argument 'dimensions' must not be null!");
-		return Positions.areDimensionsConsistentWithCoordinates(dimensions, this);
-	}
+    /**
+     * Checks if the position is consistent with the given dimensions. Conformity means that the position contains
+     * exactly one coordinate for each dimension in the given set of dimensions (classes of coordinates).
+     * 
+     * @param dimensions the dimensions for which conformity has to be checked.
+     * @return {@code true} if the position is conform, {@code false} if not.
+     */
+    public boolean isConsistentWith(Set<Class<?>> dimensions) {
+        Preconditions.checkArgument(dimensions != null, "Argument 'dimensions' must not be null!");
+        return Positions.areDimensionsConsistentWithCoordinates(dimensions, this);
+    }
 
-	@Override
-	public String toString() {
-		return "Position [coordinates=" + coordinates + "]";
-	}
+    @Override
+    public String toString() {
+        return "Position [coordinates=" + coordinates + "]";
+    }
 
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((coordinates == null) ? 0 : coordinates.hashCode());
-		return result;
-	}
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((coordinates == null) ? 0 : coordinates.hashCode());
+        return result;
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj == null) {
-			return false;
-		}
-		if (getClass() != obj.getClass()) {
-			return false;
-		}
-		Position other = (Position) obj;
-		if (coordinates == null) {
-			if (other.coordinates != null) {
-				return false;
-			}
-		} else if (!coordinates.equals(other.coordinates)) {
-			return false;
-		}
-		return true;
-	}
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        Position other = (Position) obj;
+        if (coordinates == null) {
+            if (other.coordinates != null) {
+                return false;
+            }
+        } else if (!coordinates.equals(other.coordinates)) {
+            return false;
+        }
+        return true;
+    }
 
 }

--- a/src/java/org/tensorics/core/tensor/Scalar.java
+++ b/src/java/org/tensorics/core/tensor/Scalar.java
@@ -1,0 +1,37 @@
+package org.tensorics.core.tensor;
+
+/**
+ * The specialization of a tensor with zero dimensions and exactly one value. In
+ * detail, implementations have to guarantee the following:
+ * <ul>
+ * <li>Has exactly one value (not zero, no more)
+ * <li>has always zero dimensions
+ * <li>The only valid position to query is the 'empty' position
+ * </ul>
+ * Still, a scalar can have a context. Indeed, this is a very valuable property
+ * in the framework of tensorics.
+ * <p>
+ * NOTE: It might sometimes be confusing, that in mathematics and commons
+ * language the term 'scalar' is sometimes used interchangible for a
+ * zero-dimensional tensor (what this class represents) and the values/entries
+ * of the tensors itself. Therefore, we will denote the values of a tensor
+ * (scalar) as 'values' and zero-dimensional tensors as scalars.
+ * 
+ * @author kaifox
+ *
+ * @param <V>
+ *            the type of the value of the scalar
+ */
+public interface Scalar<V> extends Tensor<V> {
+
+	/**
+	 * Has to retrieve the value of the scalar. In implementations, this has to
+	 * be equivalent to calling {@link #get(Object...)} with an empty array of
+	 * coordinates and with calling {@link #get(Position)} with an empty
+	 * position.
+	 * 
+	 * @return the internal value of the scalar
+	 */
+	public V value();
+
+}

--- a/src/java/org/tensorics/core/tensor/Scalar.java
+++ b/src/java/org/tensorics/core/tensor/Scalar.java
@@ -1,37 +1,32 @@
 package org.tensorics.core.tensor;
 
 /**
- * The specialization of a tensor with zero dimensions and exactly one value. In
- * detail, implementations have to guarantee the following:
+ * The specialization of a tensor with zero dimensions and exactly one value. In detail, implementations have to
+ * guarantee the following:
  * <ul>
  * <li>Has exactly one value (not zero, no more)
  * <li>has always zero dimensions
  * <li>The only valid position to query is the 'empty' position
  * </ul>
- * Still, a scalar can have a context. Indeed, this is a very valuable property
- * in the framework of tensorics.
+ * Still, a scalar can have a context. Indeed, this is a very valuable property in the framework of tensorics.
  * <p>
- * NOTE: It might sometimes be confusing, that in mathematics and commons
- * language the term 'scalar' is sometimes used interchangible for a
- * zero-dimensional tensor (what this class represents) and the values/entries
- * of the tensors itself. Therefore, we will denote the values of a tensor
- * (scalar) as 'values' and zero-dimensional tensors as scalars.
+ * NOTE: It might sometimes be confusing, that in mathematics and commons language the term 'scalar' is sometimes used
+ * interchangible for a zero-dimensional tensor (what this class represents) and the values/entries of the tensors
+ * itself. Therefore, we will denote the values of a tensor (scalar) as 'values' and zero-dimensional tensors as
+ * scalars.
  * 
  * @author kaifox
- *
- * @param <V>
- *            the type of the value of the scalar
+ * @param <V> the type of the value of the scalar
  */
 public interface Scalar<V> extends Tensor<V> {
 
-	/**
-	 * Has to retrieve the value of the scalar. In implementations, this has to
-	 * be equivalent to calling {@link #get(Object...)} with an empty array of
-	 * coordinates and with calling {@link #get(Position)} with an empty
-	 * position.
-	 * 
-	 * @return the internal value of the scalar
-	 */
-	public V value();
+    /**
+     * Has to retrieve the value of the scalar. In implementations, this has to be equivalent to calling
+     * {@link #get(Object...)} with an empty array of coordinates and with calling {@link #get(Position)} with an empty
+     * position.
+     * 
+     * @return the internal value of the scalar
+     */
+    public V value();
 
 }

--- a/src/java/org/tensorics/core/tensor/Shapes.java
+++ b/src/java/org/tensorics/core/tensor/Shapes.java
@@ -141,7 +141,6 @@ public final class Shapes {
                 .unique(transform(shape.positionSet(), toGuavaFunction(Positions.stripping(dimensionsToStrip)))));
     }
 
-    
     /**
      * Constructs a shape that contains all positions resulting from the outer product of the positions of the left
      * shape with those of the right shape. It is required that the two shapes have no overlap of dimensions (i.e. none
@@ -194,7 +193,8 @@ public final class Shapes {
         if (left.dimensionality() != right.dimensionality()) {
             throw new IllegalArgumentException("Left and right shape do not have the same dimensionality!");
         }
-        Set<Class<?>> dimensionalIntersection = Coordinates.parentClassIntersection(left.dimensionSet(), right.dimensionSet());
+        Set<Class<?>> dimensionalIntersection = Coordinates.parentClassIntersection(left.dimensionSet(),
+                right.dimensionSet());
         if (dimensionalIntersection.size() != left.dimensionality()) {
             throw new IllegalArgumentException("The shapes are not compatible!");
         }

--- a/src/java/org/tensorics/core/tensor/Tensor.java
+++ b/src/java/org/tensorics/core/tensor/Tensor.java
@@ -22,64 +22,51 @@
 
 package org.tensorics.core.tensor;
 
-
 /**
  * The top interface for {@link Tensor} like objects.
  * 
  * @author agorzaws, kfuchsbe
- * @param <E>
- *            type of the values hold in the tensor.
+ * @param <E> type of the values hold in the tensor.
  */
 public interface Tensor<E> {
 
-	/**
-	 * @param position
-	 *            the position in the N-dimensional space where to find the
-	 *            value.
-	 * @return the value at the given position
-	 * @throws IllegalArgumentException
-	 *             when number of coordinates is not sufficient
-	 * @throws java.util.NoSuchElementException
-	 *             if the tensor contains no element for the given position
-	 */
-	E get(Position position);
+    /**
+     * @param position the position in the N-dimensional space where to find the value.
+     * @return the value at the given position
+     * @throws IllegalArgumentException when number of coordinates is not sufficient
+     * @throws java.util.NoSuchElementException if the tensor contains no element for the given position
+     */
+    E get(Position position);
 
-	/**
-	 * @param coordinates
-	 *            form N-dimensional space where to find the value.
-	 * @return a value at the given coordinates.
-	 * @throws IllegalArgumentException
-	 *             if the number of coordinates in incorrect
-	 * @throws java.util.NoSuchElementException
-	 *             if the tensor contains no element for the position
-	 *             constructed from the given coordinates.
-	 */
-	E get(Object... coordinates);
+    /**
+     * @param coordinates form N-dimensional space where to find the value.
+     * @return a value at the given coordinates.
+     * @throws IllegalArgumentException if the number of coordinates in incorrect
+     * @throws java.util.NoSuchElementException if the tensor contains no element for the position constructed from the
+     *             given coordinates.
+     */
+    E get(Object... coordinates);
 
-	/**
-	 * Retrieves the shape of the tensor. As shape we understand simply the
-	 * structure of a tensor: Its dimensions and the available positions.
-	 * <p>
-	 * Implementations have to take care that the returned value here is never
-	 * {@code null}.
-	 * 
-	 * @return the shape of the tensor.
-	 */
-	Shape shape();
+    /**
+     * Retrieves the shape of the tensor. As shape we understand simply the structure of a tensor: Its dimensions and
+     * the available positions.
+     * <p>
+     * Implementations have to take care that the returned value here is never {@code null}.
+     * 
+     * @return the shape of the tensor.
+     */
+    Shape shape();
 
-	/**
-	 * Retrieves the context of the tensor, which is nothing else than a
-	 * position. As context of the tensor we understand coordinates within a
-	 * higher dimensional space than than the tensor has itself. This
-	 * coordinates can e.g. transport information when e.g. a higher-dimensional
-	 * tensor is split into smaller ones, so that it can potentially be
-	 * reconstructed afterwards.
-	 * <p>
-	 * Implementations have to guarantee that the returned value here is never
-	 * {@code null}.
-	 * 
-	 * @return the context of the tensor.
-	 */
-	Position context();
+    /**
+     * Retrieves the context of the tensor, which is nothing else than a position. As context of the tensor we
+     * understand coordinates within a higher dimensional space than than the tensor has itself. This coordinates can
+     * e.g. transport information when e.g. a higher-dimensional tensor is split into smaller ones, so that it can
+     * potentially be reconstructed afterwards.
+     * <p>
+     * Implementations have to guarantee that the returned value here is never {@code null}.
+     * 
+     * @return the context of the tensor.
+     */
+    Position context();
 
 }

--- a/src/java/org/tensorics/core/tensor/TensorBuilder.java
+++ b/src/java/org/tensorics/core/tensor/TensorBuilder.java
@@ -42,13 +42,13 @@ public interface TensorBuilder<E> {
     void removeAt(Position position);
 
     /**
-     * @deprecated use {@link #context(Position)} 
+     * @deprecated use {@link #context(Position)}
      */
-	@Deprecated
-	default void setTensorContext(Position context) {
-		context(context);
-	}
-    
+    @Deprecated
+    default void setTensorContext(Position context) {
+        context(context);
+    }
+
     void context(Position context);
 
     /**

--- a/src/java/org/tensorics/core/tensor/TensorPair.java
+++ b/src/java/org/tensorics/core/tensor/TensorPair.java
@@ -54,8 +54,8 @@ public final class TensorPair<V> extends AbstractPair<Tensor<V>> {
      * @throws NullPointerException if one of the arguments is {@code null}
      */
     private TensorPair(Tensor<V> leftTensor, Tensor<V> rightTensor) {
-        super(checkNotNull(leftTensor, "leftTensor must not be null"), checkNotNull(rightTensor,
-                "rightTensor must not be null"));
+        super(checkNotNull(leftTensor, "leftTensor must not be null"),
+                checkNotNull(rightTensor, "rightTensor must not be null"));
     }
 
     public static <V> TensorPair<V> fromLeftRight(Tensor<V> leftTensor, Tensor<V> rightTensor) {

--- a/src/java/org/tensorics/core/tensor/lang/OngoingDeferredQuantifiedTensorOperation.java
+++ b/src/java/org/tensorics/core/tensor/lang/OngoingDeferredQuantifiedTensorOperation.java
@@ -39,8 +39,8 @@ import org.tensorics.core.tree.domain.ResolvedExpression;
  * @author kfuchsbe
  * @param <S> the type of the scalar values (elements of the fields)
  */
-public class OngoingDeferredQuantifiedTensorOperation<S> implements
-        OngoingOperation<Expression<Tensor<QuantifiedValue<S>>>, QuantifiedValue<S>> {
+public class OngoingDeferredQuantifiedTensorOperation<S>
+        implements OngoingOperation<Expression<Tensor<QuantifiedValue<S>>>, QuantifiedValue<S>> {
 
     private final QuantityOperationRepository<S> pseudoField;
     private final Expression<Tensor<QuantifiedValue<S>>> left;
@@ -77,12 +77,12 @@ public class OngoingDeferredQuantifiedTensorOperation<S> implements
 
     @Override
     public Expression<Tensor<QuantifiedValue<S>>> elementDividedByV(QuantifiedValue<S> value) {
-        return elementDividedByQT(Tensorics.zeroDimensionalOf(value));
+        return elementDividedByQT(Tensorics.scalarOf(value));
     }
 
     @Override
     public Expression<Tensor<QuantifiedValue<S>>> elementTimesV(QuantifiedValue<S> right) {
-        return elementTimes(ResolvedExpression.of(Tensorics.zeroDimensionalOf(right)));
+        return elementTimes(ResolvedExpression.of(Tensorics.scalarOf(right)));
     }
 
     @Override

--- a/src/java/org/tensorics/core/tensor/lang/OngoingDeferredTensorOperation.java
+++ b/src/java/org/tensorics/core/tensor/lang/OngoingDeferredTensorOperation.java
@@ -2,7 +2,7 @@
  /*******************************************************************************
  *
  * This file is part of tensorics.
- * 
+ *
  * Copyright (c) 2008-2011, CERN. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  ******************************************************************************/
 // @formatter:on
 
@@ -37,7 +37,7 @@ import org.tensorics.core.tree.domain.ResolvedExpression;
 /**
  * Part of the fluent API for binary (and higher) operations on tensors. It provides methods to define the remaining
  * operands.
- * 
+ *
  * @author agorzaws, kfuchbe
  * @param <V>
  */
@@ -49,7 +49,7 @@ public class OngoingDeferredTensorOperation<V> implements OngoingOperation<Expre
 
     /**
      * Creates a new instance of the this ongoing operation.
-     * 
+     *
      * @param field the field to use
      * @param optionRegistry the registry containing all the options to use for the following operations
      * @param left the expression to be used as the left operand of the following operations
@@ -63,7 +63,7 @@ public class OngoingDeferredTensorOperation<V> implements OngoingOperation<Expre
 
     /**
      * Creates an expression that describes the addition of two tensor expressions.
-     * 
+     *
      * @param right as tensor to add
      * @return result of summing two tensors
      */
@@ -79,7 +79,7 @@ public class OngoingDeferredTensorOperation<V> implements OngoingOperation<Expre
 
     @Override
     public Expression<Tensor<V>> elementDividedByV(V value) {
-        Tensor<V> right = Tensorics.zeroDimensionalOf(value);
+        Tensor<V> right = Tensorics.scalarOf(value);
         return elementDividedBy(ResolvedExpression.of(right));
     }
 
@@ -90,7 +90,7 @@ public class OngoingDeferredTensorOperation<V> implements OngoingOperation<Expre
 
     @Override
     public Expression<Tensor<V>> elementTimesV(V value) {
-        Tensor<V> right = Tensorics.zeroDimensionalOf(value);
+        Tensor<V> right = Tensorics.scalarOf(value);
         return elementTimes(ResolvedExpression.of(right));
     }
 

--- a/src/java/org/tensorics/core/tensor/lang/OngoingQuantifiedTensorOperation.java
+++ b/src/java/org/tensorics/core/tensor/lang/OngoingQuantifiedTensorOperation.java
@@ -2,7 +2,7 @@
  /*******************************************************************************
  *
  * This file is part of tensorics.
- * 
+ *
  * Copyright (c) 2008-2011, CERN. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  ******************************************************************************/
 // @formatter:on
 
@@ -33,12 +33,12 @@ import org.tensorics.core.tensor.operations.ElementBinaryOperation;
 /**
  * Part of the tensorics fluent API that provides methods to describe the right hand part of binary operations on
  * tensors containing quantified values.
- * 
+ *
  * @author kfuchsbe
  * @param <S> the type of the scalars (elements of the field on which all the operations are based on)
  */
-public class OngoingQuantifiedTensorOperation<S> implements
-        OngoingOperation<Tensor<QuantifiedValue<S>>, QuantifiedValue<S>> {
+public class OngoingQuantifiedTensorOperation<S>
+        implements OngoingOperation<Tensor<QuantifiedValue<S>>, QuantifiedValue<S>> {
 
     private final QuantityOperationRepository<S> operationRepository;
     private final Tensor<QuantifiedValue<S>> left;
@@ -67,7 +67,7 @@ public class OngoingQuantifiedTensorOperation<S> implements
 
     @Override
     public Tensor<QuantifiedValue<S>> elementTimesV(QuantifiedValue<S> right) {
-        return elementTimes(Tensorics.zeroDimensionalOf(right));
+        return elementTimes(Tensorics.scalarOf(right));
     }
 
     @Override
@@ -77,13 +77,13 @@ public class OngoingQuantifiedTensorOperation<S> implements
 
     @Override
     public Tensor<QuantifiedValue<S>> elementDividedByV(QuantifiedValue<S> value) {
-        Tensor<QuantifiedValue<S>> right = Tensorics.zeroDimensionalOf(value);
+        Tensor<QuantifiedValue<S>> right = Tensorics.scalarOf(value);
         return elementDividedBy(right);
     }
 
     private Tensor<QuantifiedValue<S>> evaluate(Tensor<QuantifiedValue<S>> right,
             BinaryOperation<QuantifiedValue<S>> operation) {
-        return new ElementBinaryOperation<>(operation, operationRepository.environment().options())
-                .perform(left, right);
+        return new ElementBinaryOperation<>(operation, operationRepository.environment().options()).perform(left,
+                right);
     }
 }

--- a/src/java/org/tensorics/core/tensor/lang/OngoingTensorManipulation.java
+++ b/src/java/org/tensorics/core/tensor/lang/OngoingTensorManipulation.java
@@ -126,7 +126,7 @@ public class OngoingTensorManipulation<V> {
         @SuppressWarnings("unchecked")
         Class<C> dimension = (Class<C>) coordinate.getClass();
         Class<? super C> correctDimension = Coordinates.mapToAnEntry(dimension, tensor.shape().dimensionSet());
-        
+
         return TensorStructurals.from(tensor).reduce(correctDimension).bySlicingAt(coordinate);
     }
 

--- a/src/java/org/tensorics/core/tensor/lang/OngoingTensorOperation.java
+++ b/src/java/org/tensorics/core/tensor/lang/OngoingTensorOperation.java
@@ -81,7 +81,7 @@ public class OngoingTensorOperation<C, V> implements OngoingOperation<Tensor<V>,
 
     @Override
     public Tensor<V> elementDividedByV(V value) {
-        return elementDividedBy(Tensorics.zeroDimensionalOf(value));
+        return elementDividedBy(Tensorics.scalarOf(value));
     }
 
     private Tensor<V> evaluate(Tensor<V> right, BinaryOperation<V> operation) {
@@ -90,7 +90,7 @@ public class OngoingTensorOperation<C, V> implements OngoingOperation<Tensor<V>,
 
     @Override
     public Tensor<V> elementTimesV(V right) {
-        return elementTimes(Tensorics.zeroDimensionalOf(right));
+        return elementTimes(Tensorics.scalarOf(right));
     }
 
     @Override
@@ -107,8 +107,8 @@ public class OngoingTensorOperation<C, V> implements OngoingOperation<Tensor<V>,
      * @see InnerTensorOperation
      */
     public Tensor<V> times(Tensor<V> right) {
-        return new InnerTensorOperation<V>(environment.field().multiplication(),
-                new IterableSum<>(environment.field()), environment.options()).perform(left, right);
+        return new InnerTensorOperation<V>(environment.field().multiplication(), new IterableSum<>(environment.field()),
+                environment.options()).perform(left, right);
     }
 
 }

--- a/src/java/org/tensorics/core/tensor/operations/ElementBinaryFunction.java
+++ b/src/java/org/tensorics/core/tensor/operations/ElementBinaryFunction.java
@@ -60,7 +60,8 @@ public class ElementBinaryFunction<V, R> implements BinaryFunction<Tensor<V>, Te
         return strategy.contextForLeftRight(left.context(), right.context());
     }
 
-    private Tensor<R> performOperation(Tensor<V> left, Tensor<V> right, Shape resultingShape, Position resultingContext) {
+    private Tensor<R> performOperation(Tensor<V> left, Tensor<V> right, Shape resultingShape,
+            Position resultingContext) {
         Builder<R> tensorBuilder = ImmutableTensor.builder(resultingShape.dimensionSet());
         for (Position position : resultingShape.positionSet()) {
             tensorBuilder.at(position).put(operation.perform(left.get(position), right.get(position)));

--- a/src/java/org/tensorics/core/tensor/operations/ElementBinaryOperation.java
+++ b/src/java/org/tensorics/core/tensor/operations/ElementBinaryOperation.java
@@ -36,14 +36,14 @@ import org.tensorics.core.tensor.options.ShapingStrategy;
  * <p>
  * To decide on the resulting shape of the tensor, two strategies are used here:
  * <ul>
- * <li> {@link BroadcastingStrategy}
- * <li> {@link ShapingStrategy}
+ * <li>{@link BroadcastingStrategy}
+ * <li>{@link ShapingStrategy}
  * </ul>
  * 
  * @author kfuchsbe
  * @param <V> The type of the tensor values
  */
-public class ElementBinaryOperation<V> extends ElementBinaryFunction<V, V> implements BinaryOperation<Tensor<V>> {
+public class ElementBinaryOperation<V> extends ElementBinaryFunction<V, V>implements BinaryOperation<Tensor<V>> {
 
     public ElementBinaryOperation(BinaryOperation<V> operation, OptionRegistry<ManipulationOption> optionRegistry) {
         super(operation, optionRegistry);

--- a/src/java/org/tensorics/core/tensor/operations/FunctionTensorCreationOperation.java
+++ b/src/java/org/tensorics/core/tensor/operations/FunctionTensorCreationOperation.java
@@ -30,7 +30,6 @@ import org.tensorics.core.tensor.Position;
 import org.tensorics.core.tensor.Shape;
 import org.tensorics.core.tensor.Tensor;
 
-
 /**
  * Uses the given function from a position to the tensor to create the values of the tensor.
  * 

--- a/src/java/org/tensorics/core/tensor/operations/InnerTensorOperation.java
+++ b/src/java/org/tensorics/core/tensor/operations/InnerTensorOperation.java
@@ -120,10 +120,10 @@ public class InnerTensorOperation<V> implements BinaryOperation<Tensor<V>> {
         Set<Class<?>> leftDimensionsToReduce = CoContraDimensionPairs.leftDimensionsIn(pairsToReduce);
         Set<Class<?>> rightDimensionsToReduce = CoContraDimensionPairs.rightDimensionsIn(pairsToReduce);
 
-        Set<Class<?>> remainingLeftDimensions = Sets.difference(broadcasted.left().shape().dimensionSet(),
-                leftDimensionsToReduce).immutableCopy();
-        Set<Class<?>> remainingRightDimensions = Sets.difference(broadcasted.right().shape().dimensionSet(),
-                rightDimensionsToReduce).immutableCopy();
+        Set<Class<?>> remainingLeftDimensions = Sets
+                .difference(broadcasted.left().shape().dimensionSet(), leftDimensionsToReduce).immutableCopy();
+        Set<Class<?>> remainingRightDimensions = Sets
+                .difference(broadcasted.right().shape().dimensionSet(), rightDimensionsToReduce).immutableCopy();
 
         Set<Class<?>> targetDimensions = Sets.union(remainingLeftDimensions, remainingRightDimensions).immutableCopy();
         Set<Class<?>> remainingCommonDimensions = Sets.intersection(remainingLeftDimensions, remainingRightDimensions);
@@ -133,8 +133,8 @@ public class InnerTensorOperation<V> implements BinaryOperation<Tensor<V>> {
          */
         Set<Class<?>> uniqueLeftDimensions = Sets.difference(remainingLeftDimensions, remainingCommonDimensions);
         Set<Class<?>> uniqueRightDimensions = Sets.difference(remainingRightDimensions, remainingCommonDimensions);
-        Multimap<Position, Position> nonUniqueToRightPositions = Positions.mapByStripping(broadcasted.right().shape()
-                .positionSet(), uniqueRightDimensions);
+        Multimap<Position, Position> nonUniqueToRightPositions = Positions
+                .mapByStripping(broadcasted.right().shape().positionSet(), uniqueRightDimensions);
 
         DimensionStripper stripper = Positions.stripping(uniqueLeftDimensions);
 

--- a/src/java/org/tensorics/core/tensor/operations/OngoingMapOut.java
+++ b/src/java/org/tensorics/core/tensor/operations/OngoingMapOut.java
@@ -59,7 +59,8 @@ public final class OngoingMapOut<V> {
 
         tensorBuilder.context(tensor.context()); // XXX IS this correct?
 
-        Multimap<Set<?>, Entry<Position, V>> fullEntries = groupBy(TensorInternals.mapFrom(tensor).entrySet(), dimension);
+        Multimap<Set<?>, Entry<Position, V>> fullEntries = groupBy(TensorInternals.mapFrom(tensor).entrySet(),
+                dimension);
         for (Set<?> key : fullEntries.keySet()) {
             Map<C1, V> values = mapByDimension(fullEntries.get(key), dimension);
             tensorBuilder.at(Position.of(key)).put(values);

--- a/src/java/org/tensorics/core/tensor/operations/PositionFunctions.java
+++ b/src/java/org/tensorics/core/tensor/operations/PositionFunctions.java
@@ -26,7 +26,6 @@ import java.util.function.Supplier;
 
 import org.tensorics.core.tensor.Position;
 
-
 public final class PositionFunctions {
 
     private PositionFunctions() {

--- a/src/java/org/tensorics/core/tensor/operations/TensorInternals.java
+++ b/src/java/org/tensorics/core/tensor/operations/TensorInternals.java
@@ -45,56 +45,51 @@ import com.google.common.collect.ImmutableMap;
  */
 public final class TensorInternals {
 
-	private TensorInternals() {
-		/* only static methods */
-	}
+    private TensorInternals() {
+        /* only static methods */
+    }
 
-	public static <T> OngoingMapOut<T> mapOut(Tensor<T> tensor) {
-		return new OngoingMapOut<>(tensor);
-	}
+    public static <T> OngoingMapOut<T> mapOut(Tensor<T> tensor) {
+        return new OngoingMapOut<>(tensor);
+    }
 
-	public static <T> Set<Entry<Position, T>> entrySetOf(Tensor<T> tensor) {
-		return mapFrom(tensor).entrySet();
-	}
+    public static <T> Set<Entry<Position, T>> entrySetOf(Tensor<T> tensor) {
+        return mapFrom(tensor).entrySet();
+    }
 
-	public static <S> Tensor<S> sameValues(Shape shape, S value) {
-		return new SingleValueTensorCreationOperation<S>(shape, value).perform();
-	}
+    public static <S> Tensor<S> sameValues(Shape shape, S value) {
+        return new SingleValueTensorCreationOperation<S>(shape, value).perform();
+    }
 
-	public static <S> Tensor<S> createFrom(Shape shape, Supplier<S> supplier) {
-		return new FunctionTensorCreationOperation<>(shape, forSupplier(supplier)).perform();
-	}
+    public static <S> Tensor<S> createFrom(Shape shape, Supplier<S> supplier) {
+        return new FunctionTensorCreationOperation<>(shape, forSupplier(supplier)).perform();
+    }
 
-	public static <S> Tensor<S> createFrom(Shape shape, Function<Position, S> function) {
-		return new FunctionTensorCreationOperation<>(shape, function).perform();
-	}
+    public static <S> Tensor<S> createFrom(Shape shape, Function<Position, S> function) {
+        return new FunctionTensorCreationOperation<>(shape, function).perform();
+    }
 
-	/**
-	 * Returns a map representing the content of the given tensor. The concrete
-	 * instance of the map might differ depending on the implementation of the
-	 * passed in tensor: Tensor implementations can offer a more efficient way
-	 * to retrieve a map from them, by implementing the {@link MappableTensor}
-	 * interface. If this interface is present, then its
-	 * {@link MappableTensor#asMap()} method will be called. Otherwise, as a
-	 * fallback, a new immutable map will be created from information from the
-	 * shape of the passed in tensor and its values.
-	 * 
-	 * @param tensor
-	 *            the tensor from which a map should be returned
-	 * @return a map representing the content of the tensor
-	 * @throws NullPointerException
-	 *             in case the passed in tensor is {@code null}
-	 */
-	public static <V> Map<Position, V> mapFrom(Tensor<V> tensor) {
-		requireNonNull(tensor, "tensor must not be null");
-		if (tensor instanceof MappableTensor) {
-			return ((MappableTensor<V>) tensor).asMap();
-		}
-		ImmutableMap.Builder<Position, V> builder = ImmutableMap.builder();
-		for (Position position : tensor.shape().positionSet()) {
-			builder.put(position, tensor.get(position));
-		}
-		return builder.build();
-	}
+    /**
+     * Returns a map representing the content of the given tensor. The concrete instance of the map might differ
+     * depending on the implementation of the passed in tensor: Tensor implementations can offer a more efficient way to
+     * retrieve a map from them, by implementing the {@link MappableTensor} interface. If this interface is present,
+     * then its {@link MappableTensor#asMap()} method will be called. Otherwise, as a fallback, a new immutable map will
+     * be created from information from the shape of the passed in tensor and its values.
+     * 
+     * @param tensor the tensor from which a map should be returned
+     * @return a map representing the content of the tensor
+     * @throws NullPointerException in case the passed in tensor is {@code null}
+     */
+    public static <V> Map<Position, V> mapFrom(Tensor<V> tensor) {
+        requireNonNull(tensor, "tensor must not be null");
+        if (tensor instanceof MappableTensor) {
+            return ((MappableTensor<V>) tensor).asMap();
+        }
+        ImmutableMap.Builder<Position, V> builder = ImmutableMap.builder();
+        for (Position position : tensor.shape().positionSet()) {
+            builder.put(position, tensor.get(position));
+        }
+        return builder.build();
+    }
 
 }

--- a/src/java/org/tensorics/core/tensor/operations/TensorInternals.java
+++ b/src/java/org/tensorics/core/tensor/operations/TensorInternals.java
@@ -75,7 +75,7 @@ public final class TensorInternals {
 	 * passed in tensor: Tensor implementations can offer a more efficient way
 	 * to retrieve a map from them, by implementing the {@link MappableTensor}
 	 * interface. If this interface is present, then its
-	 * {@link MappableTensor#asMapOld()} method will be called. Otherwise, as a
+	 * {@link MappableTensor#asMap()()} method will be called. Otherwise, as a
 	 * fallback, a new immutable map will be created from information from the
 	 * shape of the passed in tensor and its values.
 	 * 

--- a/src/java/org/tensorics/core/tensor/operations/TensorReduction.java
+++ b/src/java/org/tensorics/core/tensor/operations/TensorReduction.java
@@ -36,36 +36,33 @@ import org.tensorics.core.tensor.Tensor;
  * The operation which describes the reduction of a tensor in one direction.
  * 
  * @author kfuchsbe
- * @param <C>
- *            the dimension (direction, type of coordinate) in which the tensor
- *            will be reduced
- * @param <E>
- *            the type of the elements of the tensor
+ * @param <C> the dimension (direction, type of coordinate) in which the tensor will be reduced
+ * @param <E> the type of the elements of the tensor
  */
 public class TensorReduction<C, E, R> implements Conversion<Tensor<E>, Tensor<R>> {
 
-	private final Class<? extends C> direction;
-	private final ReductionStrategy<? super C, E, R> reductionStrategy;
+    private final Class<? extends C> direction;
+    private final ReductionStrategy<? super C, E, R> reductionStrategy;
 
-	public TensorReduction(Class<? extends C> direction, ReductionStrategy<? super C, E, R> strategy) {
-		super();
-		this.direction = direction;
-		this.reductionStrategy = strategy;
-	}
+    public TensorReduction(Class<? extends C> direction, ReductionStrategy<? super C, E, R> strategy) {
+        super();
+        this.direction = direction;
+        this.reductionStrategy = strategy;
+    }
 
-	@Override
-	public Tensor<R> apply(Tensor<E> value) {
-		Tensor<Map<C, E>> mapped = TensorInternals.mapOut(value).inDirectionOf(direction);
+    @Override
+    public Tensor<R> apply(Tensor<E> value) {
+        Tensor<Map<C, E>> mapped = TensorInternals.mapOut(value).inDirectionOf(direction);
 
-		Builder<R> builder = ImmutableTensor.builder(mapped.shape().dimensionSet());
-		builder.context(reductionStrategy.context(value.context()));
-		for (Entry<Position, Map<C, E>> entry : TensorInternals.mapFrom(mapped).entrySet()) {
-			R reducedValue = reductionStrategy.reduce(entry.getValue(), entry.getKey());
-			if (reducedValue != null) {
-				builder.at(entry.getKey()).put(reducedValue);
-			}
-		}
-		return builder.build();
-	}
+        Builder<R> builder = ImmutableTensor.builder(mapped.shape().dimensionSet());
+        builder.context(reductionStrategy.context(value.context()));
+        for (Entry<Position, Map<C, E>> entry : TensorInternals.mapFrom(mapped).entrySet()) {
+            R reducedValue = reductionStrategy.reduce(entry.getValue(), entry.getKey());
+            if (reducedValue != null) {
+                builder.at(entry.getKey()).put(reducedValue);
+            }
+        }
+        return builder.build();
+    }
 
 }

--- a/src/java/org/tensorics/core/tensor/package-info.java
+++ b/src/java/org/tensorics/core/tensor/package-info.java
@@ -18,4 +18,3 @@
  * <img src="./doc-files/base-hierarchy.PNG" alt="">
  */
 package org.tensorics.core.tensor;
-

--- a/src/java/org/tensorics/core/tensor/specific/ImmutableDoubleArrayBackedTensor.java
+++ b/src/java/org/tensorics/core/tensor/specific/ImmutableDoubleArrayBackedTensor.java
@@ -2,7 +2,7 @@
  /*******************************************************************************
  *
  * This file is part of tensorics.
- * 
+ *
  * Copyright (c) 2008-2011, CERN. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  ******************************************************************************/
 // @formatter:on
 package org.tensorics.core.tensor.specific;
@@ -24,104 +24,104 @@ package org.tensorics.core.tensor.specific;
 import java.util.Arrays;
 import java.util.Map;
 
+import org.tensorics.core.tensor.AbstractTensor;
 import org.tensorics.core.tensor.AbstractTensorBuilder;
 import org.tensorics.core.tensor.Position;
 import org.tensorics.core.tensor.Shape;
 import org.tensorics.core.tensor.Tensor;
 
 /**
- * A specific implementation of a tensor, that contains double values. It is
- * backed by a simple double array to minimize memory usage and improve
- * performance.
- * 
+ * A specific implementation of a tensor, that contains double values. It is backed by a simple double array to minimize
+ * memory usage and improve performance.
+ *
  * @author kaifox
  */
-public class ImmutableDoubleArrayBackedTensor implements Tensor<Double> {
+public class ImmutableDoubleArrayBackedTensor extends AbstractTensor<Double> {
 
-	private final PositionIndexer indexer;
-	private final double[] values;
-	private final Position tensorContext;
+    private final PositionIndexer indexer;
+    private final double[] values;
+    private final Position tensorContext;
 
-	public ImmutableDoubleArrayBackedTensor(Builder builder) {
-		this.indexer = builder.indexer;
-		this.values = Arrays.copyOf(builder.values, builder.values.length);
-		this.tensorContext = builder.context();
-	}
+    public ImmutableDoubleArrayBackedTensor(Builder builder) {
+        this.indexer = builder.indexer;
+        this.values = Arrays.copyOf(builder.values, builder.values.length);
+        this.tensorContext = builder.context();
+    }
 
-	@Override
-	public Double get(Position position) {
-		return values[indexer.indexFor(position)];
-	}
+    @Override
+    public Double get(Position position) {
+        return values[indexer.indexFor(position)];
+    }
 
-	@Override
-	public Double get(Object... coordinates) {
-		return get(Position.of(coordinates));
-	}
+    @Override
+    public Double get(Object... coordinates) {
+        return get(Position.of(coordinates));
+    }
 
-	@Override
-	public Shape shape() {
-		return Shape.viewOf(indexer.dimensions(), indexer.allPositions());
-	}
+    @Override
+    public Shape shape() {
+        return Shape.viewOf(indexer.dimensions(), indexer.allPositions());
+    }
 
-	@Override
-	public Position context() {
-		return this.tensorContext;
-	}
+    @Override
+    public Position context() {
+        return this.tensorContext;
+    }
 
-	public static Builder builder(PositionIndexer indexer) {
-		return new Builder(indexer);
-	}
+    public static Builder builder(PositionIndexer indexer) {
+        return new Builder(indexer);
+    }
 
-	/**
-	 * A builder for tensor which only will contain doubles
-	 * 
-	 * @author kfuchsbe
-	 */
-	public static class Builder extends AbstractTensorBuilder<Double> {
+    /**
+     * A builder for tensor which only will contain doubles
+     *
+     * @author kfuchsbe
+     */
+    public static class Builder extends AbstractTensorBuilder<Double> {
 
-		private final PositionIndexer indexer;
-		private final double[] values;
+        private final PositionIndexer indexer;
+        private final double[] values;
 
-		Builder(PositionIndexer indexer) {
-			super(indexer.dimensions());
-			this.indexer = indexer;
-			this.values = new double[indexer.arraySize()];
-		}
+        Builder(PositionIndexer indexer) {
+            super(indexer.dimensions());
+            this.indexer = indexer;
+            this.values = new double[indexer.arraySize()];
+        }
 
-		@Override
-		protected void putItAt(Double value, Position position) {
-			this.values[indexer.indexFor(position)] = value;
-		}
+        @Override
+        protected void putItAt(Double value, Position position) {
+            this.values[indexer.indexFor(position)] = value;
+        }
 
-		public void putUncheckedAt(double value, Position position) {
-			this.values[indexer.indexFor(position)] = value;
-		}
+        public void putUncheckedAt(double value, Position position) {
+            this.values[indexer.indexFor(position)] = value;
+        }
 
-		@Override
-		public ImmutableDoubleArrayBackedTensor build() {
-			return new ImmutableDoubleArrayBackedTensor(this);
-		}
+        @Override
+        public ImmutableDoubleArrayBackedTensor build() {
+            return new ImmutableDoubleArrayBackedTensor(this);
+        }
 
-		@Override
-		public void putAllMap(Map<Position, Double> newEntries) {
-			for (java.util.Map.Entry<Position, Double> one : newEntries.entrySet()) {
-				putItAt(one.getValue(), one.getKey());
-			}
-		}
+        @Override
+        public void putAllMap(Map<Position, Double> newEntries) {
+            for (java.util.Map.Entry<Position, Double> one : newEntries.entrySet()) {
+                putItAt(one.getValue(), one.getKey());
+            }
+        }
 
-		@Override
-		public void removeAt(Position position) {
-			throw new UnsupportedOperationException("Cannot remove a value");
-		}
+        @Override
+        public void removeAt(Position position) {
+            throw new UnsupportedOperationException("Cannot remove a value");
+        }
 
-		@Override
-		public void put(java.util.Map.Entry<Position, Double> entry) {
-			putAt(entry.getValue(), entry.getKey());
-		}
+        @Override
+        public void put(java.util.Map.Entry<Position, Double> entry) {
+            putAt(entry.getValue(), entry.getKey());
+        }
 
-		@Override
-		public void putAll(Tensor<Double> tensor) {
-			putAllAt(tensor);
-		}
-	}
+        @Override
+        public void putAll(Tensor<Double> tensor) {
+            putAllAt(tensor);
+        }
+    }
 }

--- a/src/java/org/tensorics/core/tensor/specific/PositionIndexer.java
+++ b/src/java/org/tensorics/core/tensor/specific/PositionIndexer.java
@@ -108,8 +108,8 @@ public final class PositionIndexer {
         }
 
         public <C> Builder put(Class<C> dimension, Set<C> newCoordinates) {
-            Preconditions.checkArgument(!this.coordinates.containsKey(dimension), "The dimension '" + dimension
-                    + "' is already present. Setting twice is not allowed.");
+            Preconditions.checkArgument(!this.coordinates.containsKey(dimension),
+                    "The dimension '" + dimension + "' is already present. Setting twice is not allowed.");
             this.coordinates.put(dimension, newCoordinates);
             return this;
         }

--- a/src/java/org/tensorics/core/tensor/stream/AbstractTensoricCollector.java
+++ b/src/java/org/tensorics/core/tensor/stream/AbstractTensoricCollector.java
@@ -49,9 +49,8 @@ public abstract class AbstractTensoricCollector<V, T, O> implements Collector<V,
 
     private final Function<V, Position> positionMapper;
     private final Function<V, T> valueMapper;
-    
-    public AbstractTensoricCollector(Function<V, Position> positionMapper,
-            Function<V, T> valueMapper) {
+
+    public AbstractTensoricCollector(Function<V, Position> positionMapper, Function<V, T> valueMapper) {
         this.positionMapper = positionMapper;
         this.valueMapper = valueMapper;
     }

--- a/src/java/org/tensorics/core/tensor/stream/TensorStreamMappers.java
+++ b/src/java/org/tensorics/core/tensor/stream/TensorStreamMappers.java
@@ -31,8 +31,8 @@ import java.util.function.Function;
 import org.tensorics.core.tensor.Position;
 
 /**
- * Utility class to create {@link Function}s to be used to map() a stream of {@code Entry<Position, T>}. Using these convenience
- * functions avoids the user having to explicitly extract the Entry, modify it and re-build it in the end.
+ * Utility class to create {@link Function}s to be used to map() a stream of {@code Entry<Position, T>}. Using these
+ * convenience functions avoids the user having to explicitly extract the Entry, modify it and re-build it in the end.
  * 
  * @author mihostet
  */

--- a/src/java/org/tensorics/core/tensor/stream/TensorStreams.java
+++ b/src/java/org/tensorics/core/tensor/stream/TensorStreams.java
@@ -31,7 +31,8 @@ import org.tensorics.core.tensor.operations.TensorInternals;
 import org.tensorics.core.tensorbacked.Tensorbacked;
 
 /**
- * Utility class for producing streams of {@code Entry<Position, T>} out of Tensors and collecting them back into Tensors.
+ * Utility class for producing streams of {@code Entry<Position, T>} out of Tensors and collecting them back into
+ * Tensors.
  *
  * @author mihostet
  */
@@ -52,8 +53,8 @@ public final class TensorStreams {
     }
 
     /**
-     * Build a collector to collect a stream of {@code Entry<Position,T>} to a generic {@code Tensor<T>} of the dimensions defined in
-     * the set of classes.
+     * Build a collector to collect a stream of {@code Entry<Position,T>} to a generic {@code Tensor<T>} of the
+     * dimensions defined in the set of classes.
      *
      * @param dimensions the dimensions of the tensor to construct
      * @return
@@ -63,8 +64,8 @@ public final class TensorStreams {
     }
 
     /**
-     * Build a collector to collect an arbitrary stream to a generic {@code Tensor<T>} of the given dimensions. Functions
-     * mapping the values to {@link Position} and T must be provided.
+     * Build a collector to collect an arbitrary stream to a generic {@code Tensor<T>} of the given dimensions.
+     * Functions mapping the values to {@link Position} and T must be provided.
      *
      * @param positionMapper function mapping stream values to Position
      * @param valueMapper function mapping stream values to tensor values
@@ -72,19 +73,19 @@ public final class TensorStreams {
      * @return
      */
     public static <V, T> TensorCollector<V, T> toTensor(Function<V, Position> positionMapper,
-                                                        Function<V, T> valueMapper, Set<Class<?>> dimensions) {
+            Function<V, T> valueMapper, Set<Class<?>> dimensions) {
         return new TensorCollector<>(dimensions, positionMapper, valueMapper);
     }
 
     /**
-     * Build a collector to collect a stream of {@code Entry<Position,T>} to a {@code Tensorbacked<T>} class. The {@link Position}s in
-     * the stream must be consistent with the dimensions of the Tensorbacked.
+     * Build a collector to collect a stream of {@code Entry<Position,T>} to a {@code Tensorbacked<T>} class. The
+     * {@link Position}s in the stream must be consistent with the dimensions of the Tensorbacked.
      *
      * @param tensorBackedClass the tensorbacked to produce
      * @return
      */
     public static <T, TB extends Tensorbacked<T>> TensorbackedCollector<Map.Entry<Position, T>, T, TB> toTensorbacked(
-        Class<TB> tensorBackedClass) {
+            Class<TB> tensorBackedClass) {
         return new TensorbackedCollector<>(tensorBackedClass, Map.Entry::getKey, Map.Entry::getValue);
     }
 
@@ -99,7 +100,7 @@ public final class TensorStreams {
      * @return
      */
     public static <V, T, TB extends Tensorbacked<T>> TensorbackedCollector<V, T, TB> toTensorbacked(
-        Class<TB> tensorBackedClass, Function<V, Position> positionMapper, Function<V, T> valueMapper) {
+            Class<TB> tensorBackedClass, Function<V, Position> positionMapper, Function<V, T> valueMapper) {
         return new TensorbackedCollector<>(tensorBackedClass, positionMapper, valueMapper);
     }
 

--- a/src/java/org/tensorics/core/tensor/variance/CoContraDimensionPairs.java
+++ b/src/java/org/tensorics/core/tensor/variance/CoContraDimensionPairs.java
@@ -124,8 +124,8 @@ public final class CoContraDimensionPairs {
      * @return one pair to use for that dimension
      */
     private static CoContraDimensionPair choose(Collection<CoContraDimensionPair> pairsForOneDimension) {
-        checkState(!pairsForOneDimension.isEmpty(), "No pairs of dimension found for one dimension-type. "
-                + "Must be some wrong call to this method.");
+        checkState(!pairsForOneDimension.isEmpty(),
+                "No pairs of dimension found for one dimension-type. " + "Must be some wrong call to this method.");
         if (pairsForOneDimension.size() == 1) {
             return Iterables.getFirst(pairsForOneDimension, null);
         }

--- a/src/java/org/tensorics/core/tensor/variance/Covariant.java
+++ b/src/java/org/tensorics/core/tensor/variance/Covariant.java
@@ -45,8 +45,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * (because tensorics treats coordinates of the same class as the same coordinate-dimension).
  * 
  * @param <C> the type of the (contravariant!) coordinate
- * @see <a href="http://en.wikipedia.org/wiki/Covariance_and_contravariance_of_vectors">
- *      http://en.wikipedia.org/wiki/Covariance_and_contravariance_of_vectors</a>
+ * @see <a href="http://en.wikipedia.org/wiki/Covariance_and_contravariance_of_vectors"> http://en.wikipedia.org/wiki/
+ *      Covariance_and_contravariance_of_vectors</a>
  * @author kfuchsbe
  */
 public class Covariant<C> {

--- a/src/java/org/tensorics/core/tensorbacked/AbstractTensorbacked.java
+++ b/src/java/org/tensorics/core/tensorbacked/AbstractTensorbacked.java
@@ -50,7 +50,7 @@ public abstract class AbstractTensorbacked<E> implements Tensorbacked<E>, Serial
         if (annotatedDimensions.equals(tensor.shape().dimensionSet())) {
             this.backingTensor = tensor;
         } else {
-            this.backingTensor = copyWithDimensions(tensor, annotatedDimensions);            
+            this.backingTensor = copyWithDimensions(tensor, annotatedDimensions);
         }
     }
 

--- a/src/java/org/tensorics/core/tensorbacked/TensorbackedBuilder.java
+++ b/src/java/org/tensorics/core/tensorbacked/TensorbackedBuilder.java
@@ -34,143 +34,137 @@ import org.tensorics.core.tensor.Position;
 import org.tensorics.core.tensor.Tensor;
 
 /**
- * A builder for tensor backed objects, which takes care that only positions
- * which are compatible with the dimensions of the foreseen underlaying tensor
- * are put into it. Internally, it uses a builder for a tensor, to which most of
- * the methods are delegated. At build time, the tensor is encapsulated in the
- * according tensor backed class.
+ * A builder for tensor backed objects, which takes care that only positions which are compatible with the dimensions of
+ * the foreseen underlaying tensor are put into it. Internally, it uses a builder for a tensor, to which most of the
+ * methods are delegated. At build time, the tensor is encapsulated in the according tensor backed class.
  * <p>
  * This class is not thread safe.
  * 
  * @author kfuchsbe
- * @param <V>
- *            the type of the values of the tensor (and thus also the tensor
- *            backed object)
- * @param <TB>
- *            the type of the tensor backed object
+ * @param <V> the type of the values of the tensor (and thus also the tensor backed object)
+ * @param <TB> the type of the tensor backed object
  */
 public class TensorbackedBuilder<V, TB extends Tensorbacked<V>> {
 
-	private final Class<TB> tensorbackedClass;
-	private final ImmutableTensor.Builder<V> tensorBuilder;
+    private final Class<TB> tensorbackedClass;
+    private final ImmutableTensor.Builder<V> tensorBuilder;
 
-	/**
-	 * Constructor for the builder, which takes the target class of the
-	 * tensorbacked as an argument. Will only be instantiated by the
-	 * neighbouring utility class. Therefore it is package private.
-	 */
-	TensorbackedBuilder(Class<TB> tensorbackedClass) {
-		this.tensorbackedClass = tensorbackedClass;
-		this.tensorBuilder = ImmutableTensor.builder(dimensionsOf(tensorbackedClass));
-	}
+    /**
+     * Constructor for the builder, which takes the target class of the tensorbacked as an argument. Will only be
+     * instantiated by the neighbouring utility class. Therefore it is package private.
+     */
+    TensorbackedBuilder(Class<TB> tensorbackedClass) {
+        this.tensorbackedClass = tensorbackedClass;
+        this.tensorBuilder = ImmutableTensor.builder(dimensionsOf(tensorbackedClass));
+    }
 
-	public final OngoingPut<V> at(Position entryPosition) {
-		return tensorBuilder.at(entryPosition);
-	}
+    public final OngoingPut<V> at(Position entryPosition) {
+        return tensorBuilder.at(entryPosition);
+    }
 
-	public final OngoingPut<V> at(Set<?> coordinates) {
-		return tensorBuilder.at(coordinates);
-	}
+    public final OngoingPut<V> at(Set<?> coordinates) {
+        return tensorBuilder.at(coordinates);
+    }
 
-	public final OngoingPut<V> at(Object... coordinates) {
-		return tensorBuilder.at(coordinates);
-	}
+    public final OngoingPut<V> at(Object... coordinates) {
+        return tensorBuilder.at(coordinates);
+    }
 
-	public final TensorbackedBuilder<V, TB> put(java.util.Map.Entry<Position, V> entry) {
-		tensorBuilder.put(entry);
-		return this;
-	}
+    public final TensorbackedBuilder<V, TB> put(java.util.Map.Entry<Position, V> entry) {
+        tensorBuilder.put(entry);
+        return this;
+    }
 
-	public final TensorbackedBuilder<V, TB> putAt(V value, Position position) {
-		tensorBuilder.putAt(value, position);
-		return this;
-	}
+    public final TensorbackedBuilder<V, TB> putAt(V value, Position position) {
+        tensorBuilder.putAt(value, position);
+        return this;
+    }
 
-	public final TensorbackedBuilder<V, TB> putAt(V value, Object... coordinates) {
-		tensorBuilder.putAt(value, coordinates);
-		return this;
-	}
+    public final TensorbackedBuilder<V, TB> putAt(V value, Object... coordinates) {
+        tensorBuilder.putAt(value, coordinates);
+        return this;
+    }
 
-	public final TensorbackedBuilder<V, TB> putAll(Set<java.util.Map.Entry<Position, V>> entries) {
-		for (java.util.Map.Entry<Position, V> entry : entries) {
-			tensorBuilder.put(entry);
-		}
-		return this;
-	}
+    public final TensorbackedBuilder<V, TB> putAll(Set<java.util.Map.Entry<Position, V>> entries) {
+        for (java.util.Map.Entry<Position, V> entry : entries) {
+            tensorBuilder.put(entry);
+        }
+        return this;
+    }
 
-	public final TensorbackedBuilder<V, TB> putAllAt(Tensor<V> tensor, Position position) {
-		tensorBuilder.putAllAt(tensor, position);
-		return this;
-	}
+    public final TensorbackedBuilder<V, TB> putAllAt(Tensor<V> tensor, Position position) {
+        tensorBuilder.putAllAt(tensor, position);
+        return this;
+    }
 
-	public final TensorbackedBuilder<V, TB> putAllAt(Tensorbacked<V> tensorbacked, Position position) {
-		tensorBuilder.putAllAt(tensorbacked.tensor(), position);
-		return this;
-	}
+    public final TensorbackedBuilder<V, TB> putAllAt(Tensorbacked<V> tensorbacked, Position position) {
+        tensorBuilder.putAllAt(tensorbacked.tensor(), position);
+        return this;
+    }
 
-	public final TensorbackedBuilder<V, TB> putAllAt(Tensor<V> tensor, Object... coordinates) {
-		tensorBuilder.putAllAt(tensor, coordinates);
-		return this;
-	}
+    public final TensorbackedBuilder<V, TB> putAllAt(Tensor<V> tensor, Object... coordinates) {
+        tensorBuilder.putAllAt(tensor, coordinates);
+        return this;
+    }
 
-	public final TensorbackedBuilder<V, TB> putAllAt(Tensorbacked<V> tensorbacked, Object... coordinates) {
-		tensorBuilder.putAllAt(tensorbacked.tensor(), coordinates);
-		return this;
-	}
+    public final TensorbackedBuilder<V, TB> putAllAt(Tensorbacked<V> tensorbacked, Object... coordinates) {
+        tensorBuilder.putAllAt(tensorbacked.tensor(), coordinates);
+        return this;
+    }
 
-	public final TensorbackedBuilder<V, TB> putAll(TB tensorBacked) {
-		tensorBuilder.putAll(tensorBacked.tensor());
-		return this;
-	}
+    public final TensorbackedBuilder<V, TB> putAll(TB tensorBacked) {
+        tensorBuilder.putAll(tensorBacked.tensor());
+        return this;
+    }
 
-	public final TensorbackedBuilder<V, TB> putAll(Tensor<V> tensor) {
-		tensorBuilder.putAll(tensor);
-		return this;
-	}
+    public final TensorbackedBuilder<V, TB> putAll(Tensor<V> tensor) {
+        tensorBuilder.putAll(tensor);
+        return this;
+    }
 
-	public final TensorbackedBuilder<V, TB> putAllMap(Map<Position, V> newEntries) {
-		tensorBuilder.putAllMap(newEntries);
-		return this;
-	}
+    public final TensorbackedBuilder<V, TB> putAllMap(Map<Position, V> newEntries) {
+        tensorBuilder.putAllMap(newEntries);
+        return this;
+    }
 
-	public final TensorbackedBuilder<V, TB> removeAt(Position position) {
-		tensorBuilder.removeAt(position);
-		return this;
-	}
+    public final TensorbackedBuilder<V, TB> removeAt(Position position) {
+        tensorBuilder.removeAt(position);
+        return this;
+    }
 
-	public final TensorbackedBuilder<V, TB> context(Position context) {
-		tensorBuilder.context(context);
-		return this;
-	}
+    public final TensorbackedBuilder<V, TB> context(Position context) {
+        tensorBuilder.context(context);
+        return this;
+    }
 
-	/**
-	 * @deprecated use {@link #context(Position)}
-	 */
-	@Deprecated
-	public final TensorbackedBuilder<V, TB> withContext(Position context) {
-		return this.context(context);
-	}
+    /**
+     * @deprecated use {@link #context(Position)}
+     */
+    @Deprecated
+    public final TensorbackedBuilder<V, TB> withContext(Position context) {
+        return this.context(context);
+    }
 
-	public final TensorbackedBuilder<V, TB> context(Object... coordinates) {
-		return this.context(Position.of(coordinates));
-	}
+    public final TensorbackedBuilder<V, TB> context(Object... coordinates) {
+        return this.context(Position.of(coordinates));
+    }
 
-	/**
-	 * @deprecated use {@link #context(Object...)}
-	 */
-	@Deprecated
-	public final TensorbackedBuilder<V, TB> withContext(Object... coordinates) {
-		return this.context(coordinates);
-	}
+    /**
+     * @deprecated use {@link #context(Object...)}
+     */
+    @Deprecated
+    public final TensorbackedBuilder<V, TB> withContext(Object... coordinates) {
+        return this.context(coordinates);
+    }
 
-	/**
-	 * Builds the tensor backed object, after all the content is set.
-	 * 
-	 * @return a new instance of the tensor backed object, containing all the
-	 *         data as described after instantiating the builder.
-	 */
-	public TB build() {
-		return createBackedByTensor(tensorbackedClass, tensorBuilder.build());
-	}
+    /**
+     * Builds the tensor backed object, after all the content is set.
+     * 
+     * @return a new instance of the tensor backed object, containing all the data as described after instantiating the
+     *         builder.
+     */
+    public TB build() {
+        return createBackedByTensor(tensorbackedClass, tensorBuilder.build());
+    }
 
 }

--- a/src/java/org/tensorics/core/tensorbacked/TensorbackedInternals.java
+++ b/src/java/org/tensorics/core/tensorbacked/TensorbackedInternals.java
@@ -57,7 +57,7 @@ public final class TensorbackedInternals {
      * @return the set of dimentions (classses of coordinates) which are required to create an instance of the given
      *         class.
      */
-    public static  <T extends Tensorbacked<?>> Set<Class<?>> dimensionsOf(Class<T> tensorBackedClass) {
+    public static <T extends Tensorbacked<?>> Set<Class<?>> dimensionsOf(Class<T> tensorBackedClass) {
         Dimensions dimensionAnnotation = tensorBackedClass.getAnnotation(Dimensions.class);
         if (dimensionAnnotation == null) {
             throw new IllegalArgumentException(

--- a/src/java/org/tensorics/core/tensorbacked/Tensorbackeds.java
+++ b/src/java/org/tensorics/core/tensorbacked/Tensorbackeds.java
@@ -116,7 +116,8 @@ public final class Tensorbackeds {
      * example:
      * 
      * <pre>
-     * {@code
+     * {
+     *     &#64;code
      *     // Assume that Orbit and OrbitTimeseries are tensorbacked objects
      *     List<> orbits = new ArrayList<>();
      *     // assume the list is filled

--- a/src/java/org/tensorics/core/tensorbacked/annotation/Dimensions.java
+++ b/src/java/org/tensorics/core/tensorbacked/annotation/Dimensions.java
@@ -38,5 +38,5 @@ import java.lang.annotation.Target;
 @Target({ ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Dimensions {
-    Class<?>[] value() default {}; // NOSONAR (no whitespace before }
+    Class<?>[]value() default {}; // NOSONAR (no whitespace before }
 }

--- a/src/java/org/tensorics/core/tensorbacked/lang/OngoingQuantifiedTensorBackedOperation.java
+++ b/src/java/org/tensorics/core/tensorbacked/lang/OngoingQuantifiedTensorBackedOperation.java
@@ -41,8 +41,8 @@ import org.tensorics.core.tensorbacked.Tensorbacked;
  * @param <QTB> the type of the quantified tensor backed instances
  * @param <S> the type of the scalars (elements of the field on which all the operations are based on)
  */
-public class OngoingQuantifiedTensorBackedOperation<QTB extends Tensorbacked<QuantifiedValue<S>>, S> implements
-        OngoingOperation<QTB, QuantifiedValue<S>> {
+public class OngoingQuantifiedTensorBackedOperation<QTB extends Tensorbacked<QuantifiedValue<S>>, S>
+        implements OngoingOperation<QTB, QuantifiedValue<S>> {
 
     private final QuantityOperationRepository<S> pseudoField;
     private final QTB left;
@@ -70,7 +70,7 @@ public class OngoingQuantifiedTensorBackedOperation<QTB extends Tensorbacked<Qua
 
     @Override
     public QTB elementTimesV(QuantifiedValue<S> right) {
-        return elementTimesQT(Tensorics.zeroDimensionalOf(right));
+        return elementTimesQT(Tensorics.scalarOf(right));
     }
 
     public QTB elementTimesQT(Tensor<QuantifiedValue<S>> right) {
@@ -92,8 +92,8 @@ public class OngoingQuantifiedTensorBackedOperation<QTB extends Tensorbacked<Qua
     }
 
     private QTB evaluate(Tensor<QuantifiedValue<S>> right, BinaryOperation<QuantifiedValue<S>> operation) {
-        Tensor<QuantifiedValue<S>> perform = new ElementBinaryOperation<>(operation, pseudoField.environment()
-                .options()).perform(left.tensor(), right);
+        Tensor<QuantifiedValue<S>> perform = new ElementBinaryOperation<>(operation,
+                pseudoField.environment().options()).perform(left.tensor(), right);
         return createBackedByTensor(classOf(left), perform);
     }
 

--- a/src/java/org/tensorics/core/tensorbacked/lang/OngoingTensorBackedOperation.java
+++ b/src/java/org/tensorics/core/tensorbacked/lang/OngoingTensorBackedOperation.java
@@ -97,7 +97,7 @@ public class OngoingTensorBackedOperation<TB extends Tensorbacked<V>, V> impleme
 
     @Override
     public TB elementTimesV(V value) {
-        return elementTimesT(Tensorics.zeroDimensionalOf(value));
+        return elementTimesT(Tensorics.scalarOf(value));
     }
 
     @Override
@@ -118,7 +118,7 @@ public class OngoingTensorBackedOperation<TB extends Tensorbacked<V>, V> impleme
 
     @Override
     public TB elementDividedByV(V value) {
-        return elementDividedByT(Tensorics.zeroDimensionalOf(value));
+        return elementDividedByT(Tensorics.scalarOf(value));
     }
 
     private TB evaluate(Tensor<V> right, BinaryOperation<V> operation) {

--- a/src/java/org/tensorics/core/tensorbacked/lang/TensorbackedExpressionSupport.java
+++ b/src/java/org/tensorics/core/tensorbacked/lang/TensorbackedExpressionSupport.java
@@ -43,8 +43,8 @@ public class TensorbackedExpressionSupport<V> {
     }
 
     public final <TB extends Tensorbacked<V>> Expression<TB> elementNegativeOfTB(Expression<TB> tensorbacked) {
-        return new UnaryOperationExpression<>(new ElementTensorBackedUnaryOperation<V, TB>(environment.field()
-                .additiveInversion()), tensorbacked);
+        return new UnaryOperationExpression<>(
+                new ElementTensorBackedUnaryOperation<V, TB>(environment.field().additiveInversion()), tensorbacked);
     }
 
     public final <TB extends Tensorbacked<V>> OngoingDeferredTensorBackedOperation<V, TB> calculateTB(

--- a/src/java/org/tensorics/core/tensorbacked/operations/ElementTensorBackedUnaryOperation.java
+++ b/src/java/org/tensorics/core/tensorbacked/operations/ElementTensorBackedUnaryOperation.java
@@ -35,8 +35,8 @@ import org.tensorics.core.tensorbacked.TensorbackedInternals;
  * @param <V> the type the values of the tensor
  * @param <TB> the type of the tensor backed object
  */
-public class ElementTensorBackedUnaryOperation<V, TB extends Tensorbacked<V>> implements
-        TensorBackedUnaryOperation<V, TB> {
+public class ElementTensorBackedUnaryOperation<V, TB extends Tensorbacked<V>>
+        implements TensorBackedUnaryOperation<V, TB> {
 
     private final UnaryOperation<V> elementOperation;
 

--- a/src/java/org/tensorics/core/tensorbacked/operations/QuantifiedElementTensorBackedUnaryOperation.java
+++ b/src/java/org/tensorics/core/tensorbacked/operations/QuantifiedElementTensorBackedUnaryOperation.java
@@ -32,8 +32,8 @@ import org.tensorics.core.tensorbacked.Tensorbacked;
  * @param <V> the type of the scalar values (elements of the field on which all the operations are based on)
  * @param <QTB>
  */
-public class QuantifiedElementTensorBackedUnaryOperation<V, QTB extends Tensorbacked<QuantifiedValue<V>>> implements
-        QuantifiedTensorBackedUnaryOperation<V, QTB> {
+public class QuantifiedElementTensorBackedUnaryOperation<V, QTB extends Tensorbacked<QuantifiedValue<V>>>
+        implements QuantifiedTensorBackedUnaryOperation<V, QTB> {
 
     @Override
     public QTB perform(QTB value) {

--- a/src/java/org/tensorics/core/tensorbacked/operations/QuantifiedTensorBackedUnaryOperation.java
+++ b/src/java/org/tensorics/core/tensorbacked/operations/QuantifiedTensorBackedUnaryOperation.java
@@ -33,7 +33,7 @@ import org.tensorics.core.tensorbacked.Tensorbacked;
  * @param <V>
  * @param <QTB>
  */
-public interface QuantifiedTensorBackedUnaryOperation<V, QTB extends Tensorbacked<QuantifiedValue<V>>> extends
-        UnaryOperation<QTB> {
+public interface QuantifiedTensorBackedUnaryOperation<V, QTB extends Tensorbacked<QuantifiedValue<V>>>
+        extends UnaryOperation<QTB> {
     /* Only a marker */
 }

--- a/src/java/org/tensorics/core/testing/hamcrest/TensorIsCloseTo.java
+++ b/src/java/org/tensorics/core/testing/hamcrest/TensorIsCloseTo.java
@@ -76,8 +76,8 @@ public class TensorIsCloseTo<S> extends TypeSafeDiagnosingMatcher<Tensor<S>> {
             mismatchDescription.appendText("the following mismatches were detected (position -> value):\n");
             for (Entry<Position, Mismatch<S>> entry : mismatches.entrySet()) {
                 Mismatch<S> mismatch = entry.getValue();
-                mismatchDescription.appendText(entry.getKey() + " -> " + mismatch.value + " | expected = "
-                        + mismatch.expected + ";\n");
+                mismatchDescription.appendText(
+                        entry.getKey() + " -> " + mismatch.value + " | expected = " + mismatch.expected + ";\n");
             }
             return false;
         }

--- a/src/java/org/tensorics/core/tree/domain/AbstractDeferredExpression.java
+++ b/src/java/org/tensorics/core/tree/domain/AbstractDeferredExpression.java
@@ -40,8 +40,8 @@ public abstract class AbstractDeferredExpression<R> implements Expression<R> {
 
     @Override
     public final R get() {
-        throw new ExpressionIsUnresolvedException("It is not possible to get the value of a deferred expression ('"
-                + this.toString() + "')");
+        throw new ExpressionIsUnresolvedException(
+                "It is not possible to get the value of a deferred expression ('" + this.toString() + "')");
     }
 
 }

--- a/src/java/org/tensorics/core/tree/walking/TreeWalker.java
+++ b/src/java/org/tensorics/core/tree/walking/TreeWalker.java
@@ -32,14 +32,14 @@ import org.tensorics.core.tree.domain.Node;
  * moments of the walk-through. The moment when a callback is called depends of the interfaces that are implemented by a
  * specific callback. Possible callbacks and their purposes are:
  * <ul>
- * <li> {@link EveryNodeCallback}: The single method of this callback will be called once for every node in the tree in
+ * <li>{@link EveryNodeCallback}: The single method of this callback will be called once for every node in the tree in
  * the order of the walkthrough.
- * <li> {@link BottomNodeCallback}: The single method of this callback will be called for every node in the tree, which
+ * <li>{@link BottomNodeCallback}: The single method of this callback will be called for every node in the tree, which
  * is a bottom node (has no children).
- * <li> {@link SkipNodeAndSubTreesCallback}: The method of this callback is called before a node (or its children) are
+ * <li>{@link SkipNodeAndSubTreesCallback}: The method of this callback is called before a node (or its children) are
  * visited. Its sole method can return a boolean flag. If the callback returns {@code true}, then the node (and all the
  * subtree starting from there) is skipped. If {@code false} is returned, the sub tree is processed normally.
- * <li> {@link StepUpCallback}: The sole method of this callback is called when some children of a node were visited and
+ * <li>{@link StepUpCallback}: The sole method of this callback is called when some children of a node were visited and
  * before the actual node is visited.
  * </ul>
  */

--- a/src/java/org/tensorics/core/util/Instantiators.java
+++ b/src/java/org/tensorics/core/util/Instantiators.java
@@ -47,11 +47,12 @@ public final class Instantiators {
      * this:
      * 
      * <pre>
-     * {@code
-     *   Instantiator<Argument, Instance> instantiator =
-     *      instantiatorFor(Instance.class).withArgumentType(Argument.class);
+     * {
+     *     &#64;code
+     *     Instantiator<Argument, Instance> instantiator = instantiatorFor(Instance.class)
+     *             .withArgumentType(Argument.class);
      * 
-     *   Instance instance = instantiator.create(anArgument); // anArgument being of type Argument
+     *     Instance instance = instantiator.create(anArgument); // anArgument being of type Argument
      * }
      * </pre>
      * 

--- a/src/java/org/tensorics/core/util/MoreMultisets.java
+++ b/src/java/org/tensorics/core/util/MoreMultisets.java
@@ -7,16 +7,16 @@ import com.google.common.collect.Multiset;
 
 public class MoreMultisets {
 
-	private MoreMultisets() {
-		/* only static methods */
-	}
+    private MoreMultisets() {
+        /* only static methods */
+    }
 
-	public static boolean containsNonUniqueElements(Multiset<?> dimensions) {
-		return dimensions.size() > dimensions.elementSet().size();
-	}
+    public static boolean containsNonUniqueElements(Multiset<?> dimensions) {
+        return dimensions.size() > dimensions.elementSet().size();
+    }
 
-	public static <T> Multiset<T> nonUniqueElementsOf(Multiset<T> dimensions) {
-		return difference(dimensions, ImmutableMultiset.copyOf(dimensions.elementSet()));
-	}
+    public static <T> Multiset<T> nonUniqueElementsOf(Multiset<T> dimensions) {
+        return difference(dimensions, ImmutableMultiset.copyOf(dimensions.elementSet()));
+    }
 
 }

--- a/src/java/org/tensorics/core/util/SingleArgumentInvokableInstantiator.java
+++ b/src/java/org/tensorics/core/util/SingleArgumentInvokableInstantiator.java
@@ -55,8 +55,9 @@ public abstract class SingleArgumentInvokableInstantiator<A, R> implements Insta
             return invokable.invoke(null, argument);
         } catch (IllegalAccessException | //
                 IllegalArgumentException | InvocationTargetException e) {
-            throw new IllegalArgumentException("Invokable of class '" + instanceClass
-                    + "' could not be invoked with argument '" + argument + "'", e);
+            throw new IllegalArgumentException(
+                    "Invokable of class '" + instanceClass + "' could not be invoked with argument '" + argument + "'",
+                    e);
         }
     }
 

--- a/src/java/org/tensorics/incubate/function/ConstantFunction.java
+++ b/src/java/org/tensorics/incubate/function/ConstantFunction.java
@@ -34,8 +34,8 @@ import com.google.common.base.Preconditions;
  * @param <QX> type of arguments
  * @param <QY> type of values
  */
-public final class ConstantFunction<QX extends Quantity, QY extends Quantity> implements
-        AnalyticalFunction<Amount<QX>, Amount<QY>> {
+public final class ConstantFunction<QX extends Quantity, QY extends Quantity>
+        implements AnalyticalFunction<Amount<QX>, Amount<QY>> {
 
     private final Amount<QY> constant;
 

--- a/src/java/org/tensorics/incubate/function/ExponentialFunction.java
+++ b/src/java/org/tensorics/incubate/function/ExponentialFunction.java
@@ -37,8 +37,8 @@ import com.google.common.base.Preconditions;
  * @param <QX> type of arguments
  * @param <QY> type of values
  */
-public class ExponentialFunction<QX extends Quantity, QY extends Quantity> implements
-        AnalyticalFunction<Amount<QX>, Amount<QY>> {
+public class ExponentialFunction<QX extends Quantity, QY extends Quantity>
+        implements AnalyticalFunction<Amount<QX>, Amount<QY>> {
 
     private final Amount<QX> inverseExpConst;
     private final Amount<QY> amplitude;
@@ -48,8 +48,8 @@ public class ExponentialFunction<QX extends Quantity, QY extends Quantity> imple
         this.inverseExpConst = builder.inverseExpConst;
 
         Preconditions.checkArgument(amplitude != null, "Argument '" + "amplitude" + "' must not be null!");
-        Preconditions.checkArgument(inverseExpConst != null, "Argument '" + "inverseExponentialConstant"
-                + "' must not be null!");
+        Preconditions.checkArgument(inverseExpConst != null,
+                "Argument '" + "inverseExponentialConstant" + "' must not be null!");
     }
 
     @Override

--- a/src/java/org/tensorics/incubate/function/Functions.java
+++ b/src/java/org/tensorics/incubate/function/Functions.java
@@ -49,7 +49,8 @@ public final class Functions {
         return convertToDiscreteFunctionFrom(times, values, errors);
     }
 
-    public static List<Double> getXsIntersection(DiscreteFunction<Double, ?> first, DiscreteFunction<Double, ?> second) {
+    public static List<Double> getXsIntersection(DiscreteFunction<Double, ?> first,
+            DiscreteFunction<Double, ?> second) {
 
         List<Double> firstTs = first.getXs();
         List<Double> secondTs = second.getXs();

--- a/src/java/org/tensorics/incubate/function/InterpolatedFunction.java
+++ b/src/java/org/tensorics/incubate/function/InterpolatedFunction.java
@@ -39,10 +39,10 @@ public final class InterpolatedFunction<X extends Comparable<X>, Y> implements C
     private InterpolatedFunction(DiscreteFunction<X, Y> function, InterpolationStrategy<X, Y> strategy) {
         this.interpolationStrategy = strategy;
         this.discreteFunction = function;
-        Preconditions
-                .checkArgument(discreteFunction != null, "Argument '" + "DiscreteFunction" + "' must not be null!");
-        Preconditions.checkArgument(interpolationStrategy != null, "Argument '" + "InterpolationStrategy"
-                + "' must not be null!");
+        Preconditions.checkArgument(discreteFunction != null,
+                "Argument '" + "DiscreteFunction" + "' must not be null!");
+        Preconditions.checkArgument(interpolationStrategy != null,
+                "Argument '" + "InterpolationStrategy" + "' must not be null!");
     }
 
     @Override

--- a/src/java/org/tensorics/incubate/function/SortedMapBackedDiscreteFunction.java
+++ b/src/java/org/tensorics/incubate/function/SortedMapBackedDiscreteFunction.java
@@ -39,8 +39,8 @@ import com.google.common.collect.ImmutableSortedMap;
  * @param <X> function arguments type
  * @param <Y> function values type
  */
-public class SortedMapBackedDiscreteFunction<X extends Comparable<X>, Y> implements DiscreteFunction<X, Y>,
-        Serializable {
+public class SortedMapBackedDiscreteFunction<X extends Comparable<X>, Y>
+        implements DiscreteFunction<X, Y>, Serializable {
     private static final long serialVersionUID = 1L;
 
     private final SortedMap<X, Y> function;

--- a/src/test/org/tensorics/core/function/MathFunctionsTest.java
+++ b/src/test/org/tensorics/core/function/MathFunctionsTest.java
@@ -17,7 +17,6 @@ import org.tensorics.core.tensor.ImmutableTensor;
 import org.tensorics.core.tensor.Position;
 import org.tensorics.core.tensor.Tensor;
 
-
 /**
  * Unit tests for {@link MathFunctions}
  * 

--- a/src/test/org/tensorics/core/lang/CoordinateRange.java
+++ b/src/test/org/tensorics/core/lang/CoordinateRange.java
@@ -30,7 +30,8 @@ public class CoordinateRange {
     private final Set<YCoordinate> yCoordinates;
     private final Set<ZCoordinate> zCoordinates;
 
-    private CoordinateRange(Set<XCoordinate> xCoordinates, Set<YCoordinate> yCoordinates, Set<ZCoordinate> zCoordinates) {
+    private CoordinateRange(Set<XCoordinate> xCoordinates, Set<YCoordinate> yCoordinates,
+            Set<ZCoordinate> zCoordinates) {
         super();
         this.xCoordinates = xCoordinates;
         this.yCoordinates = yCoordinates;

--- a/src/test/org/tensorics/core/lang/DoubleTensoricsTest.java
+++ b/src/test/org/tensorics/core/lang/DoubleTensoricsTest.java
@@ -57,7 +57,7 @@ public class DoubleTensoricsTest {
         verifyQuantifiedIterableOperationResult(DoubleTensorics::rmsOfQ, 6.204836823, AMPERE);
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testRmsOfEmptyIterableOfQuantifiedDouble() {
         iterableSample = Collections.emptyList();
         verifyQuantifiedIterableOperationResult(DoubleTensorics::rmsOfQ, 0.0, Unit.ONE);

--- a/src/test/org/tensorics/core/lang/InnerProductTest.java
+++ b/src/test/org/tensorics/core/lang/InnerProductTest.java
@@ -183,8 +183,8 @@ public class InnerProductTest extends TensoricDoubleSupport {
     }
 
     private Tensor<Double> simpleCoContraTimesCoContra() {
-        return calculate(coAndContravariant(1.0, 2.0, Coord.values())).times(
-                coAndContravariant(3.0, 4.0, Coord.values()));
+        return calculate(coAndContravariant(1.0, 2.0, Coord.values()))
+                .times(coAndContravariant(3.0, 4.0, Coord.values()));
     }
 
     private Tensor<Double> co2Contra2Multiplication() {
@@ -257,8 +257,8 @@ public class InnerProductTest extends TensoricDoubleSupport {
         Builder<Double> builder1 = ImmutableTensor.builder(Coord.class, CoCoord.class);
         for (Coord contra : coordinates) {
             for (Coord co : coordinates) {
-                builder1.at(contra, intantiator.create(co)).put(
-                        ((contra.ordinal() + 1) * contraFactor) + ((co.ordinal() + 1) * coFactor));
+                builder1.at(contra, intantiator.create(co))
+                        .put(((contra.ordinal() + 1) * contraFactor) + ((co.ordinal() + 1) * coFactor));
             }
         }
         return builder1.build();

--- a/src/test/org/tensorics/core/lang/TCoordinate.java
+++ b/src/test/org/tensorics/core/lang/TCoordinate.java
@@ -79,7 +79,7 @@ public class TCoordinate implements TestCoordinate {
         if (o.getClass().equals(this.getClass())) {
             return this.coor - ((TCoordinate) o).getValue();
         }
-        throw new IllegalArgumentException("Cannot compare two coordinates of different Type [" + this.getClass()
-                + " : " + o.getClass() + "]");
+        throw new IllegalArgumentException(
+                "Cannot compare two coordinates of different Type [" + this.getClass() + " : " + o.getClass() + "]");
     }
 }

--- a/src/test/org/tensorics/core/lang/TensorBackedSupportTest.java
+++ b/src/test/org/tensorics/core/lang/TensorBackedSupportTest.java
@@ -50,7 +50,6 @@ import org.tensorics.core.units.JScienceUnit;
 
 import com.google.common.base.Optional;
 
-
 /**
  * Test that verifies if {@link TensorSupport} is valid for {@link Tensorbacked} objects as well. Analogous tests covers
  * the and {@link QuantityTensorSupport}
@@ -122,8 +121,8 @@ public class TensorBackedSupportTest {
     @Test
     public void testTensorOfDoubleCalcDividedTensor() {
         MultibeamOrbit negativeOf = fullTensoricSupport.negativeOf(multibeamTensorBacked1);
-        MultibeamOrbit elementTimesBy = fullTensoricSupport.calculate(multibeamTensorBacked1).elementDividedBy(
-                negativeOf);
+        MultibeamOrbit elementTimesBy = fullTensoricSupport.calculate(multibeamTensorBacked1)
+                .elementDividedBy(negativeOf);
         double value3 = elementTimesBy.getValueAt("name 9", Beam.B1, Plane.H);
         assertEquals(-1, value3, 0.001);
     }

--- a/src/test/org/tensorics/core/lang/TensorCalculationsTest.java
+++ b/src/test/org/tensorics/core/lang/TensorCalculationsTest.java
@@ -65,640 +65,639 @@ import com.google.common.collect.ImmutableSet;
  */
 public class TensorCalculationsTest {
 
-	private static final int Z_COOR_NUMBER = 1;
-	private static final int Y_COOR_NUMBER = 2;
-	private static final int X_COOR_NUMBER = 512;
-
-	private Tensor<Double> tensor1;
-	private Tensor<Boolean> tensor1Flags;
-	private Tensor<Double> tensor2;
-	private Tensor<Double> tensor3Big;
-	private TensoricSupport<Double> tensoricFieldUsage;
-
-	@Before
-	public void setUp() throws Exception {
-		tensoricFieldUsage = Tensorics.using(Structures.doubles());
-		tensor1 = prepareValues(1.0);
-		tensor1Flags = prepareOnlyEvenValuesTrueFlag();
-		tensor2 = prepareValues(2.5);
-		System.out.println("============== <<<<<<<<<< NEXT TEST >>>>>>>>>> =============");
-	}
-
-	@Test
-	public void averageOverOneDimensionOnValue1() {
-		YCoordinate y = YCoordinate.of(1);
-		Tensor<Double> averagedOverX = TensorStructurals.from(tensor1).reduce(XCoordinate.class)
-				.byAveragingIn(doubles());
-		assertEquals(4.5, averagedOverX.get(Position.of(y)), 0.0);
-	}
-
-	@Test
-	public void averageOverOneDimensionKeepingOther() {
-		Tensor<Double> averageOverYCoordinte = TensorStructurals.from(tensor1).reduce(XCoordinate.class)
-				.byAveragingIn(doubles());
-		assertEquals(tensor1.shape().dimensionSet().size() - 1, averageOverYCoordinte.shape().dimensionSet().size());
-		Set<YCoordinate> coordinateValues = TensorStructurals.from(averageOverYCoordinte)
-				.extractCoordinatesOfType(YCoordinate.class);
-		assertEquals(10, coordinateValues.size());
-	}
-
-	@Test
-	public void testMultiplyByNumber() {
-		YCoordinate y = YCoordinate.of(1);
-		XCoordinate x = XCoordinate.of(3);
-		Tensor<Double> tensor = tensoricFieldUsage.calculate(tensor1).elementTimesV(-1.0);
-		assertEquals(-3, tensor.get(x, y).doubleValue(), 0.0);
-	}
-
-	@Test
-	public void testDivideByNumber() {
-		YCoordinate y = YCoordinate.of(1);
-		XCoordinate x = XCoordinate.of(3);
-		Tensor<Double> tensor = tensoricFieldUsage.calculate(tensor1).elementDividedByV(2.0);
-		assertEquals(1.5, tensor.get(x, y).doubleValue(), 0.0);
-	}
-
-	@Test
-	public void testRMSCalculation() {
-		YCoordinate y = YCoordinate.of(1);
-		double rms = TensorStructurals.from(tensor1).reduce(XCoordinate.class).byRmsIn(doubles()).get(y);
-
-		assertEquals(5.33, rms, 0.01);
-		double rms2 = TensorStructurals.from(tensor1).reduce(XCoordinate.class).byRmsIn(doubles()).get(Position.of(y));
-		assertEquals(5.33, rms2, 0.01);
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void testRMSCalculationTooManyCoordiantes() {
-		YCoordinate y = YCoordinate.of(1);
-		XCoordinate x = XCoordinate.of(2);
-		TensorStructurals.from(tensor1).reduce(XCoordinate.class).byRmsIn(doubles()).get(x, y);
-	}
-
-	@Test
-	public void testMeanCalculation() {
-		YCoordinate y = YCoordinate.of(1);
-		double mean2 = TensorStructurals.from(TensorStructurals.from(tensor1).extract(y)).reduce(XCoordinate.class)
-				.byAveragingIn(doubles()).get(Position.empty());
-		assertEquals(4.5, mean2, 0.0);
-	}
-
-	@Test
-	public void testAddition() {
-		YCoordinate y = YCoordinate.of(2);
-		XCoordinate x = XCoordinate.of(6);
-		Tensor<Double> tensor = tensoricFieldUsage.calculate(tensor1).plus(tensor1);
-		assertEquals(24.0, tensor.get(x, y).doubleValue(), 0.0);
-	}
-
-	@Test
-	public void testSubtraction() {
-		YCoordinate y = YCoordinate.of(2);
-		XCoordinate x = XCoordinate.of(6);
-		Tensor<Double> tensor = tensoricFieldUsage.calculate(tensor1).minus(tensor1);
-		assertEquals(0.0, tensor.get(x, y).doubleValue(), 0.0);
-	}
-
-	@Test
-	public void testFluentAddition() {
-		YCoordinate y = YCoordinate.of(2);
-		XCoordinate x = XCoordinate.of(6);
-		Tensor<Double> tensor = tensoricFieldUsage.calculate(tensor1).plus(tensor1);
-		assertEquals(24.0, tensor.get(x, y).doubleValue(), 0.0);
-	}
-
-	@Test
-	public void testAdditionOf2elementsTo100WithResult2() {
-		YCoordinate y = YCoordinate.of(2);
-		XCoordinate x = XCoordinate.of(6);
-		XCoordinate x2 = XCoordinate.of(3);
-
-		Builder<Double> builder = ImmutableTensor.builder(ImmutableSet.of(y.getClass(), x.getClass()));
-		builder.at(Position.of(ImmutableSet.of(x, y))).put(13.2);
-		builder.at(Position.of(ImmutableSet.of(x2, y))).put(-1.2);
-		Tensor<Double> testTensor = builder.build();
-
-		Tensor<Double> tensor = tensoricFieldUsage.calculate(tensor1).plus(testTensor);
-		assertEquals(25.2, tensor.get(x, y).doubleValue(), 0.0);
-	}
-
-	@Test
-	public void testAdditionOf2elementsTo2() {
-		YCoordinate y = YCoordinate.of(2);
-		XCoordinate x = XCoordinate.of(6);
-		XCoordinate x2 = XCoordinate.of(3);
-
-		Builder<Double> builder = ImmutableTensor.builder(ImmutableSet.of(y.getClass(), x.getClass()));
-		builder.at(Position.of(ImmutableSet.of(x, y))).put(13.2);
-		builder.at(Position.of(ImmutableSet.of(x2, y))).put(-1.2);
-		Tensor<Double> testTensor = builder.build();
-
-		Builder<Double> builder2 = ImmutableTensor.builder(ImmutableSet.of(y.getClass(), x.getClass()));
-		builder2.at(Position.of(ImmutableSet.of(x, y))).put(1.2);
-		builder2.at(Position.of(ImmutableSet.of(x2, y))).put(1.2);
-		Tensor<Double> testTensor2 = builder2.build();
-		Tensor<Double> tensor = tensoricFieldUsage.calculate(testTensor).plus(testTensor2);
-		assertEquals(14.4, tensor.get(x, y).doubleValue(), 0.001);
-	}
-
-	@Test
-	public void testFlagApplience() {
-		Tensor<Double> tensor = from(tensor1).extractWhereTrue(tensor1Flags);
-		YCoordinate y = YCoordinate.of(2);
-		XCoordinate x = XCoordinate.of(6);
-		assertEquals(12.0, tensor.get(Position.of(ImmutableSet.of(x, y))).doubleValue(), 0.0);
-		assertEquals(5, TensorStructurals.from(tensor).extractCoordinatesOfType(x.getClass()).size());
-	}
-
-	@Test(expected = NoSuchElementException.class)
-	public void testFlagApplienceFailure() {
-		Tensor<Double> tensor = from(tensor1).extractWhereTrue(tensor1Flags);
-		YCoordinate y = YCoordinate.of(2);
-		XCoordinate x = XCoordinate.of(7);
-		assertEquals(14.0, tensor.get(x, y).doubleValue(), 0.0);
-	}
-
-	@Test
-	public void testAdditionFrom2elementsTo100WithWrongShapes() {
-		XCoordinate x = XCoordinate.of(6);
-		XCoordinate x2 = XCoordinate.of(3);
-		Builder<Double> builder = ImmutableTensor.builder(ImmutableSet.of(x.getClass()));
-		double x1Add = 13.2;
-		double x2Add = -1.2;
-		builder.at(Position.of(x)).put(x1Add);
-		builder.at(Position.of(x2)).put(x2Add);
-		Tensor<Double> testTensor = builder.build();
-		Tensor<Double> result = tensoricFieldUsage.calculate(tensor1).plus(testTensor);
-
-		/*
-		 * from broadcasting the y dimension of the test tensor to the values of
-		 * tensor1 (10 values) together with the two x-coordinates, we expect a
-		 * tensor of sixe 20.
-		 */
-		assertEquals(20, result.shape().size());
-
-		checkCorrectlyAdded(x, x1Add, result);
-		checkCorrectlyAdded(x2, x2Add, result);
-	}
-
-	private void checkCorrectlyAdded(XCoordinate x, double x1Add, Tensor<Double> result) {
-		for (java.util.Map.Entry<Position, Double> entry : Tensorics.mapFrom(result).entrySet()) {
-			Position position = entry.getKey();
-			if (x.equals(position.coordinateFor(XCoordinate.class))) {
-				assertEquals(tensor1.get(position) + x1Add, entry.getValue(), 0.0000001);
-			}
-		}
-	}
-
-	@Test(expected = IllegalArgumentException.class)
-	public void testReductionOnNonExistingCoordinate() {
-		TensorStructurals.from(tensor1).extract(ZCoordinate.of(1));
-	}
-
-	@Test
-	public void testOperationsOnBig512x2x1Tensor() {
-		long totalDiff = calculateOnTensor(X_COOR_NUMBER, Y_COOR_NUMBER, Z_COOR_NUMBER, true);
-		assertTrue(totalDiff < 800);
-	}
-
-	@Test
-	@Ignore
-	public void profileTensorPreparation() {
-		int maxY = 1000;
-		int step = 100;
-		int nX = 100;
-		int nZ = 1;
-		populateCaches(maxY);
-		populatePositionCache(nX, maxY, nZ);
-		List<ProfileResult> results = new ArrayList<>();
-		for (int nY = step; nY <= maxY; nY += step) {
-			results.add(profileTensorPreparation(nX, nY, nZ));
-		}
-		printProfileResult(results);
-	}
-
-	@Test
-	@Ignore
-	public void profileDoubleTensorPreparation() {
-		int maxY = 1000;
-		int step = 100;
-		int nX = 100;
-		int nZ = 1;
-		populateCaches(maxY);
-		populatePositionCache(nX, maxY, nZ);
-		List<ProfileResult> results = new ArrayList<>();
-		for (int nY = step; nY <= maxY; nY += step) {
-			results.add(profileDoubleTensorPreparation(nX, nY, nZ));
-		}
-		printProfileResult(results);
-	}
-
-	private void printProfileResult(List<ProfileResult> results) {
-		System.out.println("Step \tSize \ttime [ms] \tmem [byte]");
-		int step = 0;
-		for (ProfileResult result : results) {
-			SystemState stateDiff = result.systemStateDiff;
-			System.out.println(step++ + "\t" + result.tensorSize + "\t" + stateDiff.getTimeInMillis() + "\t"
-					+ stateDiff.getMemoryUsageInB());
-		}
-	}
-
-	@Ignore
-	@Test
-	public void profilePositionMapPreparation() {
-		int maxY = 1000;
-		int step = 100;
-		int nX = 100;
-		int nZ = 1;
-		populateCaches(maxY);
-		populatePositionCache(nX, maxY, nZ);
-		List<ProfileResult> results = new ArrayList<>();
-		for (int nY = step; nY <= maxY; nY += step) {
-			results.add(profileMapPreparation(nX, nY, nZ));
-		}
-		printProfileResult(results);
-	}
-
-	@Test
-	@Ignore
-	public void profileSimpleMapPopulation() {
-		int maxValue = 100000;
-		int step = 10000;
-		populateCaches(maxValue);
-		List<ProfileResult> results = new ArrayList<>();
-		for (int i = step; i <= maxValue; i += step) {
-			results.add(profileXCoordinateMap(i));
-		}
-		printProfileResult(results);
-	}
-
-	private ProfileResult profileXCoordinateMap(int size) {
-		System.out.println("Map preparation preparation of size=" + size + ":");
-		SystemState initialState = currentTimeAfterGc();
-		Map<XCoordinate, Double> map = createImmutableMapOfSize(size);
-		SystemState stateDiff = currentTimeAfterGc().minus(initialState);
-		stateDiff.printToStdOut();
-		return new ProfileResult(map.size(), stateDiff);
-
-	}
-
-	private Map<XCoordinate, Double> createImmutableMapOfSize(int size) {
-		ImmutableMap.Builder<XCoordinate, Double> builder = ImmutableMap.builder();
-		for (int i = 0; i < size; i++) {
-			builder.put(XCoordinate.of(i), valueForBig(i, i, i, 2.0));
-		}
-		return builder.build();
-	}
-
-	private void populateCaches(int maxValue) {
-		for (int i = 0; i <= maxValue; i++) {
-			XCoordinate.of(i);
-			YCoordinate.of(i);
-			ZCoordinate.of(i);
-		}
-	}
-
-	private void populatePositionCache(int nX, int nY, int nZ) {
-		for (int i = 0; i <= nX; i++) {
-			for (int j = 0; j <= nY; j++) {
-				for (int k = 0; k <= nZ; k++) {
-					Position.of(coordinatesFor(i, j, k));
-				}
-			}
-		}
-	}
-
-	private ProfileResult profileTensorPreparation(int nX, int nY, int nZ) {
-		System.out.println("Tensor preparation for " + nX + "x" + nY + "x" + nZ + ":");
-		SystemState initialState = currentTimeAfterGc();
-		Tensor<Double> tensor = prepareValuesForBig(nX, nY, nZ, 2.0);
-		SystemState stateDiff = currentTimeBeforeGc().minus(initialState);
-		stateDiff.printToStdOut();
-		System.out.println("Tensor size:" + tensor.shape().size());
-		return new ProfileResult(tensor.shape().size(), stateDiff);
-	}
-
-	private ProfileResult profileMapPreparation(int nX, int nY, int nZ) {
-		System.out.println("Map preparation for " + nX + "x" + nY + "x" + nZ + ":");
-		SystemState initialState = currentTimeAfterGc();
-		Map<Position, Double> map = prepareMap(nX, nY, nZ);
-		SystemState stateDiff = currentTimeAfterGc().minus(initialState);
-		stateDiff.printToStdOut();
-		System.out.println("Map size:" + map.size());
-		return new ProfileResult(map.size(), stateDiff);
-	}
-
-	private ProfileResult profileDoubleTensorPreparation(int nX, int nY, int nZ) {
-		System.out.println("Tensor preparation for " + nX + "x" + nY + "x" + nZ + ":");
-		SystemState initialState = currentTimeAfterGc();
-		Tensor<Double> tensor = prepareValuesForBigDouble(nX, nY, nZ, 2.0);
-		SystemState stateDiff = currentTimeBeforeGc().minus(initialState);
-		stateDiff.printToStdOut();
-		System.out.println("Tensor size:" + tensor.shape().size());
-		return new ProfileResult(tensor.shape().size(), stateDiff);
-	}
-
-	@Ignore
-	@Test
-	public void profileRepetitiveMap() {
-		List<ProfileResult> results = profileMapNTimes(10);
-		printProfileResult(results);
-	}
-
-	@Ignore
-	@Test
-	public void profileSimpleRepetitiveTensor() {
-		CoordinateRange range = CoordinateRange.fromSize(TensorSize.ofXYZ(400, 500, 1));
-		System.out.println("Created range");
-
-		List<ProfileResult> results = profileTensorCreationNTimes(5, range, new ValueFactory<Double>() {
-
-			@Override
-			public Double create(int x, int y, int z) {
-				return valueForBig(x, y, z, 2.0);
-			}
-		});
-		printProfileResult(results);
-	}
-
-	@Ignore
-	@Test
-	public void profileQuantifiedRepetitiveTensor() {
-		final Unit unit = JScienceUnit.of(SI.METER);
-		CoordinateRange range = CoordinateRange.fromSize(TensorSize.ofXYZ(100, 1000, 1));
-
-		List<ProfileResult> results = profileTensorCreationNTimes(10, range,
-				new ValueFactory<QuantifiedValue<Double>>() {
-
-					@Override
-					public QuantifiedValue<Double> create(int x, int y, int z) {
-						return Tensorics.quantityOf(valueForBig(x, y, z, 2.0), unit).withError(0.0);
-					}
-				});
-		printProfileResult(results);
-	}
-
-	public List<ProfileResult> profileMapNTimes(int nTimes) {
-		List<Map<Position, Double>> maps = new ArrayList<>();
-		List<ProfileResult> results = new ArrayList<>();
-		for (int i = 0; i < nTimes; i++) {
-			SystemState initialState = currentTimeAfterGc();
-			Map<Position, Double> map = prepareMap(100, 1000, 1);
-			SystemState stateDiff = currentTimeAfterGc().minus(initialState);
-			stateDiff.printToStdOut();
-			System.out.println("Map size:" + map.size());
-			results.add(new ProfileResult(map.size(), stateDiff));
-			maps.add(map);
-		}
-		return results;
-	}
-
-	public <V> List<ProfileResult> profileTensorCreationNTimes(int nTimes, CoordinateRange range,
-			ValueFactory<V> factory) {
-		List<Tensor<V>> tensors = new ArrayList<>();
-		List<ProfileResult> results = new ArrayList<>();
-		for (int i = 0; i < nTimes; i++) {
-			SystemState initialState = currentTimeAfterGc();
-			Tensor<V> tensor = createTensor(range, factory);
-			SystemState stateDiff = currentTimeBeforeGc().minus(initialState);
-			stateDiff.printToStdOut();
-			int size = tensor.shape().size();
-			System.out.println("Tensor size:" + size);
-			results.add(new ProfileResult(size, stateDiff));
-			tensors.add(tensor);
-		}
-		return results;
-	}
-
-	private Map<Position, Double> prepareMap(int nX, int nY, int nZ) {
-		Map<Position, Double> map = new HashMap<>();
-		for (int i = 0; i < nX; i++) {
-			for (int j = 0; j < nY; j++) {
-				for (int k = 0; k < nZ; k++) {
-					map.put(Position.of(coordinatesFor(i, j, k)), valueForBig(i, j, k, 2.0));
-				}
-			}
-		}
-		return map;
-	}
-
-	private static class ProfileResult {
-		private final SystemState systemStateDiff;
-		private final int tensorSize;
-
-		public ProfileResult(int tensorSize, SystemState systemStateDiff) {
-			super();
-			this.tensorSize = tensorSize;
-			this.systemStateDiff = systemStateDiff;
-		}
-	}
-
-	@Test
-	public void testOperationsOnBig1024x2x2Tensor() {
-		long totalDiff = calculateOnTensor(X_COOR_NUMBER * 2, Y_COOR_NUMBER, Z_COOR_NUMBER * 2, true);
-		assertTrue(totalDiff < 4000);
-	}
-
-	@Test
-	public void testSimpleTensoricsTask() {
-
-		Tensor<Double> result = new TensoricTask<Double, Tensor<Double>>(
-				EnvironmentImpl.of(doubles(), ManipulationOptions.defaultOptions(doubles()))) {
-
-			@Override
-			public Tensor<Double> run() {
-				return calculate(tensor1).plus(tensor2);
-			}
-
-		}.run();
-		assertEquals(100, result.shape().size());
-	}
-
-	private long calculateOnTensor(int xCoorNumber, int yCoorNumber, int zCoorNumber, boolean printLog) {
-		long memoryBefore = getMemoryUsage();
-
-		SimpleDateFormat sdf = new SimpleDateFormat("hh:MM:ss.SSS");
-		Date date = new Date();
-		int nbOfElements = xCoorNumber * yCoorNumber * zCoorNumber;
-		if (printLog) {
-			System.out.println(" Creation of [" + xCoorNumber + "," + yCoorNumber + "," + zCoorNumber
-					+ "] (total nb of elements: " + nbOfElements + ")\t" + sdf.format(date));
-		}
-		tensor3Big = prepareValuesForBig(xCoorNumber, yCoorNumber, zCoorNumber, 1.0);
-
-		System.out.println("used memory :" + (getMemoryUsage() - memoryBefore));
-
-		YCoordinate y = YCoordinate.of(0);
-		XCoordinate x = XCoordinate.of(0);
-		ZCoordinate z = ZCoordinate.of(0);
-		Date date2 = new Date();
-		if (printLog) {
-			System.out.println("done after (" + (date2.getTime() - date.getTime()) + "ms); \n Multiplying (base*(-1))\t"
-					+ sdf.format(date2));
-		}
-		Tensor<Double> inversedTensor = tensoricFieldUsage.negativeOf(tensor3Big);
-		Date date3 = new Date();
-		if (printLog) {
-			System.out.println("done after (" + (date3.getTime() - date2.getTime())
-					+ "ms); \n Adding (base*(-1) to base)\t" + sdf.format(date3));
-		}
-		Tensor<Double> tensorOut = tensoricFieldUsage.calculate(tensor3Big).plus(inversedTensor);
-
-		Date date4 = new Date();
-		if (printLog) {
-			System.out.println("Done \t" + sdf.format(date4) + " (" + (date4.getTime() - date3.getTime()) + "ms)");
-		}
-		assertEquals(0.0, tensorOut.get(x, y, z).doubleValue(), 0.0);
-		Date date5 = new Date();
-		if (printLog) {
-			System.out.println("get value at [0,0,0] \t" + sdf.format(date5) + " done after ("
-					+ (date5.getTime() - date4.getTime()) + "ms)");
-		}
-
-		TensorStructurals.from(TensorStructurals.from(tensorOut).extract(z, y)).reduce(XCoordinate.class)
-				.byAveragingIn(doubles());
-
-		Date date6 = new Date();
-		if (printLog) {
-			System.out.println("get mean on [x,0,0] \t" + sdf.format(date6) + " done after ("
-					+ (date6.getTime() - date5.getTime()) + "ms)");
-		}
-		// Tensors.getRmsOf(tensorOut).slicingAt(ImmutableSet.of(y, z));
-		TensorStructurals.from(tensorOut).reduce(XCoordinate.class).byRmsIn(doubles()).get(y, z);
-
-		Date date7 = new Date();
-		if (printLog) {
-			System.out.println("get rms on [x,0,0] \t" + sdf.format(date7) + " done after ("
-					+ (date7.getTime() - date6.getTime()) + "ms)");
-		}
-		long totalDiff = date7.getTime() - date2.getTime();
-		if (printLog) {
-			System.out.println("Total (since first calc)  done after (" + totalDiff + "ms)");
-			System.out.println("used memory :" + (getMemoryUsage() - memoryBefore));
-			System.out.println("=====================================");
-		}
-		return totalDiff;
-	}
-
-	public long getMemoryUsage() {
-		for (int i = 0; i < 10; i++) {
-			System.gc(); // NOSONAR
-		}
-
-		int kb = 1024;
-		Runtime runtime = Runtime.getRuntime();
-
-		// Print used memory
-		long usedMemoryinKb = (runtime.totalMemory() - runtime.freeMemory()) / kb;
-		return usedMemoryinKb;
-	}
-
-	@SuppressWarnings("boxing")
-	private Tensor<Double> prepareValues(double factor) {
-		ImmutableSet<Class<?>> dimensions = ImmutableSet.of(XCoordinate.class, YCoordinate.class);
-		Builder<Double> builder = ImmutableTensor.builder(dimensions);
-		for (int i = 0; i < 10; i++) {
-			for (int j = 0; j < 10; j++) {
-				builder.at(Position.of(coordinatesFor(i, j))).put(valueFor(i, j, factor));
-			}
-		}
-		return builder.build();
-	}
-
-	private Tensor<Boolean> prepareOnlyEvenValuesTrueFlag() {
-		ImmutableSet<Class<?>> dimensions = ImmutableSet.of(XCoordinate.class, YCoordinate.class);
-		Builder<Boolean> builder = ImmutableTensor.builder(dimensions);
-		for (int i = 0; i < 10; i++) {
-			for (int j = 0; j < 10; j++) {
-				builder.at(Position.of(coordinatesFor(i, j))).put(flagFor(i, j));
-			}
-		}
-		return builder.build();
-	}
-
-	private Boolean flagFor(int i, int j) {
-		if (i % 2 == 0 && j % 2 == 0) {
-			return Boolean.TRUE;
-		}
-		return Boolean.FALSE;
-	}
-
-	private double valueFor(int i, int j, double factor) {
-		return j * i * factor;
-	}
-
-	private Set<TestCoordinate> coordinatesFor(int i, int j) {
-		Set<TestCoordinate> coordinates = new HashSet<>();
-		coordinates.add(XCoordinate.of(i));
-		coordinates.add(YCoordinate.of(j));
-		return coordinates;
-	}
-
-	private Set<TestCoordinate> coordinatesFor(int i, int j, int k) {
-		Set<TestCoordinate> coordinates = coordinatesFor(i, j);
-		coordinates.add(ZCoordinate.of(k));
-		return coordinates;
-	}
-
-	@SuppressWarnings("boxing")
-	private Tensor<Double> prepareValuesForBig(int Nx, int Ny, int Nz, final double factor) {
-		final CoordinateRange range = CoordinateRange.fromSize(TensorSize.ofXYZ(Nx, Ny, Nz));
-		return createTensor(range, new ValueFactory<Double>() {
-			@Override
-			public Double create(int x, int y, int z) {
-				return valueForBig(x, y, z, factor);
-			}
-		});
-	}
-
-	private <V> Tensor<V> createTensor(CoordinateRange range, ValueFactory<V> factory) {
-		ImmutableSet<Class<?>> dimensions = ImmutableSet.of(XCoordinate.class, YCoordinate.class, ZCoordinate.class);
-		Builder<V> builder = ImmutableTensor.builder(dimensions);
-		for (XCoordinate x : range.getxCoordinates()) {
-			for (YCoordinate y : range.getyCoordinates()) {
-				for (ZCoordinate z : range.getzCoordinates()) {
-					builder.putAt(factory.create(x.getValue(), y.getValue(), z.getValue()), Position.of(x, y, z));
-				}
-			}
-		}
-		return builder.build();
-	}
-
-	private Tensor<Double> prepareValuesForBigDouble(int Nx, int Ny, int Nz, final double factor) {
-		final CoordinateRange range = CoordinateRange.fromSize(TensorSize.ofXYZ(Nx, Ny, Nz));
-		return createDoubleTensor(range, new ValueFactory<Double>() {
-			@Override
-			public Double create(int x, int y, int z) {
-				return valueForBig(x, y, z, factor);
-			}
-		});
-	}
-
-	private Tensor<Double> createDoubleTensor(CoordinateRange range, ValueFactory<Double> factory) {
-		PositionIndexer.Builder indexerBuilder = PositionIndexer.builder();
-		indexerBuilder.put(XCoordinate.class, range.getxCoordinates());
-		indexerBuilder.put(YCoordinate.class, range.getyCoordinates());
-		indexerBuilder.put(ZCoordinate.class, range.getzCoordinates());
-		PositionIndexer indexer = indexerBuilder.build();
-
-		ImmutableDoubleArrayBackedTensor.Builder builder = ImmutableDoubleArrayBackedTensor.builder(indexer);
-		for (XCoordinate x : range.getxCoordinates()) {
-			for (YCoordinate y : range.getyCoordinates()) {
-				for (ZCoordinate z : range.getzCoordinates()) {
-					builder.putUncheckedAt(factory.create(x.getValue(), y.getValue(), z.getValue()),
-							Position.of(x, y, z));
-				}
-			}
-		}
-		return builder.build();
-	}
-
-	interface ValueFactory<V> {
-		V create(int x, int y, int z);
-	}
-
-	private double valueForBig(int i, int j, int k, double factor) {
-		return j * i * k * factor;
-	}
+    private static final int Z_COOR_NUMBER = 1;
+    private static final int Y_COOR_NUMBER = 2;
+    private static final int X_COOR_NUMBER = 512;
+
+    private Tensor<Double> tensor1;
+    private Tensor<Boolean> tensor1Flags;
+    private Tensor<Double> tensor2;
+    private Tensor<Double> tensor3Big;
+    private TensoricSupport<Double> tensoricFieldUsage;
+
+    @Before
+    public void setUp() throws Exception {
+        tensoricFieldUsage = Tensorics.using(Structures.doubles());
+        tensor1 = prepareValues(1.0);
+        tensor1Flags = prepareOnlyEvenValuesTrueFlag();
+        tensor2 = prepareValues(2.5);
+        System.out.println("============== <<<<<<<<<< NEXT TEST >>>>>>>>>> =============");
+    }
+
+    @Test
+    public void averageOverOneDimensionOnValue1() {
+        YCoordinate y = YCoordinate.of(1);
+        Tensor<Double> averagedOverX = TensorStructurals.from(tensor1).reduce(XCoordinate.class)
+                .byAveragingIn(doubles());
+        assertEquals(4.5, averagedOverX.get(Position.of(y)), 0.0);
+    }
+
+    @Test
+    public void averageOverOneDimensionKeepingOther() {
+        Tensor<Double> averageOverYCoordinte = TensorStructurals.from(tensor1).reduce(XCoordinate.class)
+                .byAveragingIn(doubles());
+        assertEquals(tensor1.shape().dimensionSet().size() - 1, averageOverYCoordinte.shape().dimensionSet().size());
+        Set<YCoordinate> coordinateValues = TensorStructurals.from(averageOverYCoordinte)
+                .extractCoordinatesOfType(YCoordinate.class);
+        assertEquals(10, coordinateValues.size());
+    }
+
+    @Test
+    public void testMultiplyByNumber() {
+        YCoordinate y = YCoordinate.of(1);
+        XCoordinate x = XCoordinate.of(3);
+        Tensor<Double> tensor = tensoricFieldUsage.calculate(tensor1).elementTimesV(-1.0);
+        assertEquals(-3, tensor.get(x, y).doubleValue(), 0.0);
+    }
+
+    @Test
+    public void testDivideByNumber() {
+        YCoordinate y = YCoordinate.of(1);
+        XCoordinate x = XCoordinate.of(3);
+        Tensor<Double> tensor = tensoricFieldUsage.calculate(tensor1).elementDividedByV(2.0);
+        assertEquals(1.5, tensor.get(x, y).doubleValue(), 0.0);
+    }
+
+    @Test
+    public void testRMSCalculation() {
+        YCoordinate y = YCoordinate.of(1);
+        double rms = TensorStructurals.from(tensor1).reduce(XCoordinate.class).byRmsIn(doubles()).get(y);
+
+        assertEquals(5.33, rms, 0.01);
+        double rms2 = TensorStructurals.from(tensor1).reduce(XCoordinate.class).byRmsIn(doubles()).get(Position.of(y));
+        assertEquals(5.33, rms2, 0.01);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testRMSCalculationTooManyCoordiantes() {
+        YCoordinate y = YCoordinate.of(1);
+        XCoordinate x = XCoordinate.of(2);
+        TensorStructurals.from(tensor1).reduce(XCoordinate.class).byRmsIn(doubles()).get(x, y);
+    }
+
+    @Test
+    public void testMeanCalculation() {
+        YCoordinate y = YCoordinate.of(1);
+        double mean2 = TensorStructurals.from(TensorStructurals.from(tensor1).extract(y)).reduce(XCoordinate.class)
+                .byAveragingIn(doubles()).get(Position.empty());
+        assertEquals(4.5, mean2, 0.0);
+    }
+
+    @Test
+    public void testAddition() {
+        YCoordinate y = YCoordinate.of(2);
+        XCoordinate x = XCoordinate.of(6);
+        Tensor<Double> tensor = tensoricFieldUsage.calculate(tensor1).plus(tensor1);
+        assertEquals(24.0, tensor.get(x, y).doubleValue(), 0.0);
+    }
+
+    @Test
+    public void testSubtraction() {
+        YCoordinate y = YCoordinate.of(2);
+        XCoordinate x = XCoordinate.of(6);
+        Tensor<Double> tensor = tensoricFieldUsage.calculate(tensor1).minus(tensor1);
+        assertEquals(0.0, tensor.get(x, y).doubleValue(), 0.0);
+    }
+
+    @Test
+    public void testFluentAddition() {
+        YCoordinate y = YCoordinate.of(2);
+        XCoordinate x = XCoordinate.of(6);
+        Tensor<Double> tensor = tensoricFieldUsage.calculate(tensor1).plus(tensor1);
+        assertEquals(24.0, tensor.get(x, y).doubleValue(), 0.0);
+    }
+
+    @Test
+    public void testAdditionOf2elementsTo100WithResult2() {
+        YCoordinate y = YCoordinate.of(2);
+        XCoordinate x = XCoordinate.of(6);
+        XCoordinate x2 = XCoordinate.of(3);
+
+        Builder<Double> builder = ImmutableTensor.builder(ImmutableSet.of(y.getClass(), x.getClass()));
+        builder.at(Position.of(ImmutableSet.of(x, y))).put(13.2);
+        builder.at(Position.of(ImmutableSet.of(x2, y))).put(-1.2);
+        Tensor<Double> testTensor = builder.build();
+
+        Tensor<Double> tensor = tensoricFieldUsage.calculate(tensor1).plus(testTensor);
+        assertEquals(25.2, tensor.get(x, y).doubleValue(), 0.0);
+    }
+
+    @Test
+    public void testAdditionOf2elementsTo2() {
+        YCoordinate y = YCoordinate.of(2);
+        XCoordinate x = XCoordinate.of(6);
+        XCoordinate x2 = XCoordinate.of(3);
+
+        Builder<Double> builder = ImmutableTensor.builder(ImmutableSet.of(y.getClass(), x.getClass()));
+        builder.at(Position.of(ImmutableSet.of(x, y))).put(13.2);
+        builder.at(Position.of(ImmutableSet.of(x2, y))).put(-1.2);
+        Tensor<Double> testTensor = builder.build();
+
+        Builder<Double> builder2 = ImmutableTensor.builder(ImmutableSet.of(y.getClass(), x.getClass()));
+        builder2.at(Position.of(ImmutableSet.of(x, y))).put(1.2);
+        builder2.at(Position.of(ImmutableSet.of(x2, y))).put(1.2);
+        Tensor<Double> testTensor2 = builder2.build();
+        Tensor<Double> tensor = tensoricFieldUsage.calculate(testTensor).plus(testTensor2);
+        assertEquals(14.4, tensor.get(x, y).doubleValue(), 0.001);
+    }
+
+    @Test
+    public void testFlagApplience() {
+        Tensor<Double> tensor = from(tensor1).extractWhereTrue(tensor1Flags);
+        YCoordinate y = YCoordinate.of(2);
+        XCoordinate x = XCoordinate.of(6);
+        assertEquals(12.0, tensor.get(Position.of(ImmutableSet.of(x, y))).doubleValue(), 0.0);
+        assertEquals(5, TensorStructurals.from(tensor).extractCoordinatesOfType(x.getClass()).size());
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testFlagApplienceFailure() {
+        Tensor<Double> tensor = from(tensor1).extractWhereTrue(tensor1Flags);
+        YCoordinate y = YCoordinate.of(2);
+        XCoordinate x = XCoordinate.of(7);
+        assertEquals(14.0, tensor.get(x, y).doubleValue(), 0.0);
+    }
+
+    @Test
+    public void testAdditionFrom2elementsTo100WithWrongShapes() {
+        XCoordinate x = XCoordinate.of(6);
+        XCoordinate x2 = XCoordinate.of(3);
+        Builder<Double> builder = ImmutableTensor.builder(ImmutableSet.of(x.getClass()));
+        double x1Add = 13.2;
+        double x2Add = -1.2;
+        builder.at(Position.of(x)).put(x1Add);
+        builder.at(Position.of(x2)).put(x2Add);
+        Tensor<Double> testTensor = builder.build();
+        Tensor<Double> result = tensoricFieldUsage.calculate(tensor1).plus(testTensor);
+
+        /*
+         * from broadcasting the y dimension of the test tensor to the values of tensor1 (10 values) together with the
+         * two x-coordinates, we expect a tensor of sixe 20.
+         */
+        assertEquals(20, result.shape().size());
+
+        checkCorrectlyAdded(x, x1Add, result);
+        checkCorrectlyAdded(x2, x2Add, result);
+    }
+
+    private void checkCorrectlyAdded(XCoordinate x, double x1Add, Tensor<Double> result) {
+        for (java.util.Map.Entry<Position, Double> entry : Tensorics.mapFrom(result).entrySet()) {
+            Position position = entry.getKey();
+            if (x.equals(position.coordinateFor(XCoordinate.class))) {
+                assertEquals(tensor1.get(position) + x1Add, entry.getValue(), 0.0000001);
+            }
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testReductionOnNonExistingCoordinate() {
+        TensorStructurals.from(tensor1).extract(ZCoordinate.of(1));
+    }
+
+    @Test
+    public void testOperationsOnBig512x2x1Tensor() {
+        long totalDiff = calculateOnTensor(X_COOR_NUMBER, Y_COOR_NUMBER, Z_COOR_NUMBER, true);
+        assertTrue(totalDiff < 800);
+    }
+
+    @Test
+    @Ignore
+    public void profileTensorPreparation() {
+        int maxY = 1000;
+        int step = 100;
+        int nX = 100;
+        int nZ = 1;
+        populateCaches(maxY);
+        populatePositionCache(nX, maxY, nZ);
+        List<ProfileResult> results = new ArrayList<>();
+        for (int nY = step; nY <= maxY; nY += step) {
+            results.add(profileTensorPreparation(nX, nY, nZ));
+        }
+        printProfileResult(results);
+    }
+
+    @Test
+    @Ignore
+    public void profileDoubleTensorPreparation() {
+        int maxY = 1000;
+        int step = 100;
+        int nX = 100;
+        int nZ = 1;
+        populateCaches(maxY);
+        populatePositionCache(nX, maxY, nZ);
+        List<ProfileResult> results = new ArrayList<>();
+        for (int nY = step; nY <= maxY; nY += step) {
+            results.add(profileDoubleTensorPreparation(nX, nY, nZ));
+        }
+        printProfileResult(results);
+    }
+
+    private void printProfileResult(List<ProfileResult> results) {
+        System.out.println("Step \tSize \ttime [ms] \tmem [byte]");
+        int step = 0;
+        for (ProfileResult result : results) {
+            SystemState stateDiff = result.systemStateDiff;
+            System.out.println(step++ + "\t" + result.tensorSize + "\t" + stateDiff.getTimeInMillis() + "\t"
+                    + stateDiff.getMemoryUsageInB());
+        }
+    }
+
+    @Ignore
+    @Test
+    public void profilePositionMapPreparation() {
+        int maxY = 1000;
+        int step = 100;
+        int nX = 100;
+        int nZ = 1;
+        populateCaches(maxY);
+        populatePositionCache(nX, maxY, nZ);
+        List<ProfileResult> results = new ArrayList<>();
+        for (int nY = step; nY <= maxY; nY += step) {
+            results.add(profileMapPreparation(nX, nY, nZ));
+        }
+        printProfileResult(results);
+    }
+
+    @Test
+    @Ignore
+    public void profileSimpleMapPopulation() {
+        int maxValue = 100000;
+        int step = 10000;
+        populateCaches(maxValue);
+        List<ProfileResult> results = new ArrayList<>();
+        for (int i = step; i <= maxValue; i += step) {
+            results.add(profileXCoordinateMap(i));
+        }
+        printProfileResult(results);
+    }
+
+    private ProfileResult profileXCoordinateMap(int size) {
+        System.out.println("Map preparation preparation of size=" + size + ":");
+        SystemState initialState = currentTimeAfterGc();
+        Map<XCoordinate, Double> map = createImmutableMapOfSize(size);
+        SystemState stateDiff = currentTimeAfterGc().minus(initialState);
+        stateDiff.printToStdOut();
+        return new ProfileResult(map.size(), stateDiff);
+
+    }
+
+    private Map<XCoordinate, Double> createImmutableMapOfSize(int size) {
+        ImmutableMap.Builder<XCoordinate, Double> builder = ImmutableMap.builder();
+        for (int i = 0; i < size; i++) {
+            builder.put(XCoordinate.of(i), valueForBig(i, i, i, 2.0));
+        }
+        return builder.build();
+    }
+
+    private void populateCaches(int maxValue) {
+        for (int i = 0; i <= maxValue; i++) {
+            XCoordinate.of(i);
+            YCoordinate.of(i);
+            ZCoordinate.of(i);
+        }
+    }
+
+    private void populatePositionCache(int nX, int nY, int nZ) {
+        for (int i = 0; i <= nX; i++) {
+            for (int j = 0; j <= nY; j++) {
+                for (int k = 0; k <= nZ; k++) {
+                    Position.of(coordinatesFor(i, j, k));
+                }
+            }
+        }
+    }
+
+    private ProfileResult profileTensorPreparation(int nX, int nY, int nZ) {
+        System.out.println("Tensor preparation for " + nX + "x" + nY + "x" + nZ + ":");
+        SystemState initialState = currentTimeAfterGc();
+        Tensor<Double> tensor = prepareValuesForBig(nX, nY, nZ, 2.0);
+        SystemState stateDiff = currentTimeBeforeGc().minus(initialState);
+        stateDiff.printToStdOut();
+        System.out.println("Tensor size:" + tensor.shape().size());
+        return new ProfileResult(tensor.shape().size(), stateDiff);
+    }
+
+    private ProfileResult profileMapPreparation(int nX, int nY, int nZ) {
+        System.out.println("Map preparation for " + nX + "x" + nY + "x" + nZ + ":");
+        SystemState initialState = currentTimeAfterGc();
+        Map<Position, Double> map = prepareMap(nX, nY, nZ);
+        SystemState stateDiff = currentTimeAfterGc().minus(initialState);
+        stateDiff.printToStdOut();
+        System.out.println("Map size:" + map.size());
+        return new ProfileResult(map.size(), stateDiff);
+    }
+
+    private ProfileResult profileDoubleTensorPreparation(int nX, int nY, int nZ) {
+        System.out.println("Tensor preparation for " + nX + "x" + nY + "x" + nZ + ":");
+        SystemState initialState = currentTimeAfterGc();
+        Tensor<Double> tensor = prepareValuesForBigDouble(nX, nY, nZ, 2.0);
+        SystemState stateDiff = currentTimeBeforeGc().minus(initialState);
+        stateDiff.printToStdOut();
+        System.out.println("Tensor size:" + tensor.shape().size());
+        return new ProfileResult(tensor.shape().size(), stateDiff);
+    }
+
+    @Ignore
+    @Test
+    public void profileRepetitiveMap() {
+        List<ProfileResult> results = profileMapNTimes(10);
+        printProfileResult(results);
+    }
+
+    @Ignore
+    @Test
+    public void profileSimpleRepetitiveTensor() {
+        CoordinateRange range = CoordinateRange.fromSize(TensorSize.ofXYZ(400, 500, 1));
+        System.out.println("Created range");
+
+        List<ProfileResult> results = profileTensorCreationNTimes(5, range, new ValueFactory<Double>() {
+
+            @Override
+            public Double create(int x, int y, int z) {
+                return valueForBig(x, y, z, 2.0);
+            }
+        });
+        printProfileResult(results);
+    }
+
+    @Ignore
+    @Test
+    public void profileQuantifiedRepetitiveTensor() {
+        final Unit unit = JScienceUnit.of(SI.METER);
+        CoordinateRange range = CoordinateRange.fromSize(TensorSize.ofXYZ(100, 1000, 1));
+
+        List<ProfileResult> results = profileTensorCreationNTimes(10, range,
+                new ValueFactory<QuantifiedValue<Double>>() {
+
+                    @Override
+                    public QuantifiedValue<Double> create(int x, int y, int z) {
+                        return Tensorics.quantityOf(valueForBig(x, y, z, 2.0), unit).withError(0.0);
+                    }
+                });
+        printProfileResult(results);
+    }
+
+    public List<ProfileResult> profileMapNTimes(int nTimes) {
+        List<Map<Position, Double>> maps = new ArrayList<>();
+        List<ProfileResult> results = new ArrayList<>();
+        for (int i = 0; i < nTimes; i++) {
+            SystemState initialState = currentTimeAfterGc();
+            Map<Position, Double> map = prepareMap(100, 1000, 1);
+            SystemState stateDiff = currentTimeAfterGc().minus(initialState);
+            stateDiff.printToStdOut();
+            System.out.println("Map size:" + map.size());
+            results.add(new ProfileResult(map.size(), stateDiff));
+            maps.add(map);
+        }
+        return results;
+    }
+
+    public <V> List<ProfileResult> profileTensorCreationNTimes(int nTimes, CoordinateRange range,
+            ValueFactory<V> factory) {
+        List<Tensor<V>> tensors = new ArrayList<>();
+        List<ProfileResult> results = new ArrayList<>();
+        for (int i = 0; i < nTimes; i++) {
+            SystemState initialState = currentTimeAfterGc();
+            Tensor<V> tensor = createTensor(range, factory);
+            SystemState stateDiff = currentTimeBeforeGc().minus(initialState);
+            stateDiff.printToStdOut();
+            int size = tensor.shape().size();
+            System.out.println("Tensor size:" + size);
+            results.add(new ProfileResult(size, stateDiff));
+            tensors.add(tensor);
+        }
+        return results;
+    }
+
+    private Map<Position, Double> prepareMap(int nX, int nY, int nZ) {
+        Map<Position, Double> map = new HashMap<>();
+        for (int i = 0; i < nX; i++) {
+            for (int j = 0; j < nY; j++) {
+                for (int k = 0; k < nZ; k++) {
+                    map.put(Position.of(coordinatesFor(i, j, k)), valueForBig(i, j, k, 2.0));
+                }
+            }
+        }
+        return map;
+    }
+
+    private static class ProfileResult {
+        private final SystemState systemStateDiff;
+        private final int tensorSize;
+
+        public ProfileResult(int tensorSize, SystemState systemStateDiff) {
+            super();
+            this.tensorSize = tensorSize;
+            this.systemStateDiff = systemStateDiff;
+        }
+    }
+
+    @Test
+    public void testOperationsOnBig1024x2x2Tensor() {
+        long totalDiff = calculateOnTensor(X_COOR_NUMBER * 2, Y_COOR_NUMBER, Z_COOR_NUMBER * 2, true);
+        assertTrue(totalDiff < 4000);
+    }
+
+    @Test
+    public void testSimpleTensoricsTask() {
+
+        Tensor<Double> result = new TensoricTask<Double, Tensor<Double>>(
+                EnvironmentImpl.of(doubles(), ManipulationOptions.defaultOptions(doubles()))) {
+
+            @Override
+            public Tensor<Double> run() {
+                return calculate(tensor1).plus(tensor2);
+            }
+
+        }.run();
+        assertEquals(100, result.shape().size());
+    }
+
+    private long calculateOnTensor(int xCoorNumber, int yCoorNumber, int zCoorNumber, boolean printLog) {
+        long memoryBefore = getMemoryUsage();
+
+        SimpleDateFormat sdf = new SimpleDateFormat("hh:MM:ss.SSS");
+        Date date = new Date();
+        int nbOfElements = xCoorNumber * yCoorNumber * zCoorNumber;
+        if (printLog) {
+            System.out.println(" Creation of [" + xCoorNumber + "," + yCoorNumber + "," + zCoorNumber
+                    + "] (total nb of elements: " + nbOfElements + ")\t" + sdf.format(date));
+        }
+        tensor3Big = prepareValuesForBig(xCoorNumber, yCoorNumber, zCoorNumber, 1.0);
+
+        System.out.println("used memory :" + (getMemoryUsage() - memoryBefore));
+
+        YCoordinate y = YCoordinate.of(0);
+        XCoordinate x = XCoordinate.of(0);
+        ZCoordinate z = ZCoordinate.of(0);
+        Date date2 = new Date();
+        if (printLog) {
+            System.out.println("done after (" + (date2.getTime() - date.getTime()) + "ms); \n Multiplying (base*(-1))\t"
+                    + sdf.format(date2));
+        }
+        Tensor<Double> inversedTensor = tensoricFieldUsage.negativeOf(tensor3Big);
+        Date date3 = new Date();
+        if (printLog) {
+            System.out.println("done after (" + (date3.getTime() - date2.getTime())
+                    + "ms); \n Adding (base*(-1) to base)\t" + sdf.format(date3));
+        }
+        Tensor<Double> tensorOut = tensoricFieldUsage.calculate(tensor3Big).plus(inversedTensor);
+
+        Date date4 = new Date();
+        if (printLog) {
+            System.out.println("Done \t" + sdf.format(date4) + " (" + (date4.getTime() - date3.getTime()) + "ms)");
+        }
+        assertEquals(0.0, tensorOut.get(x, y, z).doubleValue(), 0.0);
+        Date date5 = new Date();
+        if (printLog) {
+            System.out.println("get value at [0,0,0] \t" + sdf.format(date5) + " done after ("
+                    + (date5.getTime() - date4.getTime()) + "ms)");
+        }
+
+        TensorStructurals.from(TensorStructurals.from(tensorOut).extract(z, y)).reduce(XCoordinate.class)
+                .byAveragingIn(doubles());
+
+        Date date6 = new Date();
+        if (printLog) {
+            System.out.println("get mean on [x,0,0] \t" + sdf.format(date6) + " done after ("
+                    + (date6.getTime() - date5.getTime()) + "ms)");
+        }
+        // Tensors.getRmsOf(tensorOut).slicingAt(ImmutableSet.of(y, z));
+        TensorStructurals.from(tensorOut).reduce(XCoordinate.class).byRmsIn(doubles()).get(y, z);
+
+        Date date7 = new Date();
+        if (printLog) {
+            System.out.println("get rms on [x,0,0] \t" + sdf.format(date7) + " done after ("
+                    + (date7.getTime() - date6.getTime()) + "ms)");
+        }
+        long totalDiff = date7.getTime() - date2.getTime();
+        if (printLog) {
+            System.out.println("Total (since first calc)  done after (" + totalDiff + "ms)");
+            System.out.println("used memory :" + (getMemoryUsage() - memoryBefore));
+            System.out.println("=====================================");
+        }
+        return totalDiff;
+    }
+
+    public long getMemoryUsage() {
+        for (int i = 0; i < 10; i++) {
+            System.gc(); // NOSONAR
+        }
+
+        int kb = 1024;
+        Runtime runtime = Runtime.getRuntime();
+
+        // Print used memory
+        long usedMemoryinKb = (runtime.totalMemory() - runtime.freeMemory()) / kb;
+        return usedMemoryinKb;
+    }
+
+    @SuppressWarnings("boxing")
+    private Tensor<Double> prepareValues(double factor) {
+        ImmutableSet<Class<?>> dimensions = ImmutableSet.of(XCoordinate.class, YCoordinate.class);
+        Builder<Double> builder = ImmutableTensor.builder(dimensions);
+        for (int i = 0; i < 10; i++) {
+            for (int j = 0; j < 10; j++) {
+                builder.at(Position.of(coordinatesFor(i, j))).put(valueFor(i, j, factor));
+            }
+        }
+        return builder.build();
+    }
+
+    private Tensor<Boolean> prepareOnlyEvenValuesTrueFlag() {
+        ImmutableSet<Class<?>> dimensions = ImmutableSet.of(XCoordinate.class, YCoordinate.class);
+        Builder<Boolean> builder = ImmutableTensor.builder(dimensions);
+        for (int i = 0; i < 10; i++) {
+            for (int j = 0; j < 10; j++) {
+                builder.at(Position.of(coordinatesFor(i, j))).put(flagFor(i, j));
+            }
+        }
+        return builder.build();
+    }
+
+    private Boolean flagFor(int i, int j) {
+        if (i % 2 == 0 && j % 2 == 0) {
+            return Boolean.TRUE;
+        }
+        return Boolean.FALSE;
+    }
+
+    private double valueFor(int i, int j, double factor) {
+        return j * i * factor;
+    }
+
+    private Set<TestCoordinate> coordinatesFor(int i, int j) {
+        Set<TestCoordinate> coordinates = new HashSet<>();
+        coordinates.add(XCoordinate.of(i));
+        coordinates.add(YCoordinate.of(j));
+        return coordinates;
+    }
+
+    private Set<TestCoordinate> coordinatesFor(int i, int j, int k) {
+        Set<TestCoordinate> coordinates = coordinatesFor(i, j);
+        coordinates.add(ZCoordinate.of(k));
+        return coordinates;
+    }
+
+    @SuppressWarnings("boxing")
+    private Tensor<Double> prepareValuesForBig(int Nx, int Ny, int Nz, final double factor) {
+        final CoordinateRange range = CoordinateRange.fromSize(TensorSize.ofXYZ(Nx, Ny, Nz));
+        return createTensor(range, new ValueFactory<Double>() {
+            @Override
+            public Double create(int x, int y, int z) {
+                return valueForBig(x, y, z, factor);
+            }
+        });
+    }
+
+    private <V> Tensor<V> createTensor(CoordinateRange range, ValueFactory<V> factory) {
+        ImmutableSet<Class<?>> dimensions = ImmutableSet.of(XCoordinate.class, YCoordinate.class, ZCoordinate.class);
+        Builder<V> builder = ImmutableTensor.builder(dimensions);
+        for (XCoordinate x : range.getxCoordinates()) {
+            for (YCoordinate y : range.getyCoordinates()) {
+                for (ZCoordinate z : range.getzCoordinates()) {
+                    builder.putAt(factory.create(x.getValue(), y.getValue(), z.getValue()), Position.of(x, y, z));
+                }
+            }
+        }
+        return builder.build();
+    }
+
+    private Tensor<Double> prepareValuesForBigDouble(int Nx, int Ny, int Nz, final double factor) {
+        final CoordinateRange range = CoordinateRange.fromSize(TensorSize.ofXYZ(Nx, Ny, Nz));
+        return createDoubleTensor(range, new ValueFactory<Double>() {
+            @Override
+            public Double create(int x, int y, int z) {
+                return valueForBig(x, y, z, factor);
+            }
+        });
+    }
+
+    private Tensor<Double> createDoubleTensor(CoordinateRange range, ValueFactory<Double> factory) {
+        PositionIndexer.Builder indexerBuilder = PositionIndexer.builder();
+        indexerBuilder.put(XCoordinate.class, range.getxCoordinates());
+        indexerBuilder.put(YCoordinate.class, range.getyCoordinates());
+        indexerBuilder.put(ZCoordinate.class, range.getzCoordinates());
+        PositionIndexer indexer = indexerBuilder.build();
+
+        ImmutableDoubleArrayBackedTensor.Builder builder = ImmutableDoubleArrayBackedTensor.builder(indexer);
+        for (XCoordinate x : range.getxCoordinates()) {
+            for (YCoordinate y : range.getyCoordinates()) {
+                for (ZCoordinate z : range.getzCoordinates()) {
+                    builder.putUncheckedAt(factory.create(x.getValue(), y.getValue(), z.getValue()),
+                            Position.of(x, y, z));
+                }
+            }
+        }
+        return builder.build();
+    }
+
+    interface ValueFactory<V> {
+        V create(int x, int y, int z);
+    }
+
+    private double valueForBig(int i, int j, int k, double factor) {
+        return j * i * k * factor;
+    }
 
 }

--- a/src/test/org/tensorics/core/lang/TensorsTest.java
+++ b/src/test/org/tensorics/core/lang/TensorsTest.java
@@ -129,8 +129,8 @@ public class TensorsTest {
     }
 
     private Tensor<Double> prepareTensorWithContextOf(Set<?> coordinateForContext) {
-        Builder<Double> tensorBuilder = ImmutableTensor.<Double> builder(ImmutableSet.of(XCoordinate.class,
-                YCoordinate.class));
+        Builder<Double> tensorBuilder = ImmutableTensor
+                .<Double> builder(ImmutableSet.of(XCoordinate.class, YCoordinate.class));
         if (coordinateForContext.size() > 0) {
             tensorBuilder.context(Position.of(coordinateForContext));
         }

--- a/src/test/org/tensorics/core/lang/XCoordinate.java
+++ b/src/test/org/tensorics/core/lang/XCoordinate.java
@@ -82,7 +82,7 @@ public class XCoordinate implements TestCoordinate {
         if (o.getClass().equals(this.getClass())) {
             return this.coor - ((XCoordinate) o).getValue();
         }
-        throw new IllegalArgumentException("Cannot compare two coordinates of different Type [" + this.getClass()
-                + " : " + o.getClass() + "]");
+        throw new IllegalArgumentException(
+                "Cannot compare two coordinates of different Type [" + this.getClass() + " : " + o.getClass() + "]");
     }
 }

--- a/src/test/org/tensorics/core/lang/YCoordinate.java
+++ b/src/test/org/tensorics/core/lang/YCoordinate.java
@@ -82,8 +82,8 @@ public class YCoordinate implements TestCoordinate {
         if (o.getClass().equals(this.getClass())) {
             return this.coor - ((YCoordinate) o).getValue();
         }
-        throw new IllegalArgumentException("Cannot compare two coordinates of different Type [" + this.getClass()
-                + " : " + o.getClass() + "]");
+        throw new IllegalArgumentException(
+                "Cannot compare two coordinates of different Type [" + this.getClass() + " : " + o.getClass() + "]");
     }
 
 }

--- a/src/test/org/tensorics/core/lang/ZCoordinate.java
+++ b/src/test/org/tensorics/core/lang/ZCoordinate.java
@@ -82,7 +82,7 @@ public class ZCoordinate implements TestCoordinate {
         if (o.getClass().equals(this.getClass())) {
             return this.coor - ((ZCoordinate) o).getValue();
         }
-        throw new IllegalArgumentException("Cannot compare two coordinates of different Type [" + this.getClass()
-                + " : " + o.getClass() + "]");
+        throw new IllegalArgumentException(
+                "Cannot compare two coordinates of different Type [" + this.getClass() + " : " + o.getClass() + "]");
     }
 }

--- a/src/test/org/tensorics/core/quantity/ImmutableQuantifiedScalarTest.java
+++ b/src/test/org/tensorics/core/quantity/ImmutableQuantifiedScalarTest.java
@@ -68,7 +68,7 @@ public class ImmutableQuantifiedScalarTest {
         assertEquals(10.5, DoubleTensorics.absoluteValueOf(scalar).value(), 0.000001);
         assertEquals(42.5, DoubleTensorics.absoluteValueOf(negativeScalar).value(), 0.000001);
     }
-    
+
     @Test
     public void serializableAndDeserializedIsEquals() throws IOException, ClassNotFoundException {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();

--- a/src/test/org/tensorics/core/quantity/QuantifiedPredicatesTest.java
+++ b/src/test/org/tensorics/core/quantity/QuantifiedPredicatesTest.java
@@ -29,13 +29,13 @@ public class QuantifiedPredicatesTest {
         final TensoricSupport<Double> withLowConfidence = DoubleTensorics.with(confidenceLevelOf(0.68));
         assertTrue(withLowConfidence.testIf(v1).isLessThan(v2));
         assertTrue(withLowConfidence.testIf(v1).isLessThan(v3));
-    }    
+    }
 
     @Test
     public void compareExactToErrorous() {
         ImmutableQuantifiedValue<Double> v1 = Tensorics.quantityOf(99.9, SI.METER);
         ImmutableQuantifiedValue<Double> v2 = Tensorics.quantityOf(100.0, SI.METER).withError(0.1);
-        
+
         assertFalse(DoubleTensorics.testIf(v1).isLessThan(v2));
         assertFalse(DoubleTensorics.testIf(v2).isGreaterThan(v1));
         assertFalse(DoubleTensorics.testIf(v2).isLessThan(v1));
@@ -43,18 +43,18 @@ public class QuantifiedPredicatesTest {
 
         v1 = v1.withError(0.0);
         v2 = v2.withError(0.01);
-        
+
         assertTrue(DoubleTensorics.testIf(v1).isLessThan(v2));
         assertTrue(DoubleTensorics.testIf(v2).isGreaterThan(v1));
         assertFalse(DoubleTensorics.testIf(v2).isLessThan(v1));
         assertFalse(DoubleTensorics.testIf(v1).isGreaterThan(v2));
     }
-    
+
     @Test
     public void compareExactValues() {
         ImmutableQuantifiedValue<Double> v1 = Tensorics.quantityOf(99.9, SI.METER);
         ImmutableQuantifiedValue<Double> v2 = Tensorics.quantityOf(100.0, SI.METER);
-        
+
         assertTrue(DoubleTensorics.testIf(v1).isLessThan(v2));
         assertTrue(DoubleTensorics.testIf(v2).isGreaterThan(v1));
         assertFalse(DoubleTensorics.testIf(v2).isLessThan(v1));
@@ -62,7 +62,7 @@ public class QuantifiedPredicatesTest {
 
         v1 = v1.withError(0.0);
         v2 = v2.withError(0.0);
-        
+
         assertTrue(DoubleTensorics.testIf(v1).isLessThan(v2));
         assertTrue(DoubleTensorics.testIf(v2).isGreaterThan(v1));
         assertFalse(DoubleTensorics.testIf(v2).isLessThan(v1));
@@ -73,7 +73,7 @@ public class QuantifiedPredicatesTest {
     public void compareZeros() {
         QuantifiedValue<Double> v1 = Tensorics.quantityOf(0.0, SI.METER).withError(0.0);
         QuantifiedValue<Double> v2 = Tensorics.quantityOf(0.0, SI.METER).withError(0.0);
-        
+
         assertFalse(DoubleTensorics.testIf(v1).isLessThan(v2));
         assertFalse(DoubleTensorics.testIf(v1).isGreaterThan(v2));
     }
@@ -81,19 +81,20 @@ public class QuantifiedPredicatesTest {
     @Test
     public void compareEqualValue() {
         QuantifiedValue<Double> v1 = Tensorics.quantityOf(99.9, SI.METER);
-        
+
         assertFalse(DoubleTensorics.testIf(v1).isLessThan(v1));
         assertFalse(DoubleTensorics.testIf(v1).isGreaterThan(v1));
     }
-    
-    @Test(expected=IllegalArgumentException.class)
+
+    @Test(expected = IllegalArgumentException.class)
     public void throwOnInconsistentUnits() {
         QuantifiedValue<Double> v1 = Tensorics.quantityOf(100.0, SI.METER).withError(90.0);
         QuantifiedValue<Double> v2 = Tensorics.quantityOf(190.0, SI.AMPERE).withError(1.0);
-        
+
         DoubleTensorics.testIf(v1).isLessThan(v2);
         DoubleTensorics.testIf(v1).isGreaterThan(v2);
     }
+
     @Test
     public void convertUnitsForComparison() {
         QuantifiedValue<Double> v1 = Tensorics.quantityOf(1.0, SI.METER).withError(0.01);
@@ -101,6 +102,6 @@ public class QuantifiedPredicatesTest {
 
         assertFalse(DoubleTensorics.testIf(v1).isLessThan(v2));
         assertTrue(DoubleTensorics.testIf(v1).isGreaterThan(v2));
-    }    
+    }
 
 }

--- a/src/test/org/tensorics/core/reduction/InterpolationAtTest.java
+++ b/src/test/org/tensorics/core/reduction/InterpolationAtTest.java
@@ -54,13 +54,13 @@ public class InterpolationAtTest {
         Tensor<Double> bySlicingAt = Tensorics.from(testTenosor).reduce(ComparableCoordinate.class)
                 .bySlicingAt(NOT_COMPLETE_COMPARABLE_COORDINATE_IN_THE_MIDDLE);
 
-        assertEquals(BIG_TENSOR_PROPER_SLICE_SIZE - NUMBER_OF_INCOPLETE_IN_THE_MIDDLE, bySlicingAt.shape()
-                .positionSet().size());
+        assertEquals(BIG_TENSOR_PROPER_SLICE_SIZE - NUMBER_OF_INCOPLETE_IN_THE_MIDDLE,
+                bySlicingAt.shape().positionSet().size());
 
         bySlicingAt = Tensorics.from(testTenosor).reduce(ComparableCoordinate.class)
                 .bySlicingAt(NOT_COMPLETE_COMPARABLE_COORDINATE_AT_THE_END);
-        assertEquals(BIG_TENSOR_PROPER_SLICE_SIZE - NUMBER_OF_INCOPLETE_AT_THE_END, bySlicingAt.shape().positionSet()
-                .size());
+        assertEquals(BIG_TENSOR_PROPER_SLICE_SIZE - NUMBER_OF_INCOPLETE_AT_THE_END,
+                bySlicingAt.shape().positionSet().size());
     }
 
     @Test
@@ -73,10 +73,14 @@ public class InterpolationAtTest {
 
         assertEquals(BIG_TENSOR_PROPER_SLICE_SIZE, interpolated.shape().positionSet().size());
 
-        assertEquals(interpolated.get(new TestNameCoordinate("TEST1"), TestEnum.ENUM1), 2.0, DOUBLE_COMPARISON_TOLERANCE);
-        assertEquals(interpolated.get(new TestNameCoordinate("TEST2"), TestEnum.ENUM1), 2.5, DOUBLE_COMPARISON_TOLERANCE);
-        assertEquals(interpolated.get(new TestNameCoordinate("TEST1"), TestEnum.ENUM2), 2.0, DOUBLE_COMPARISON_TOLERANCE);
-        assertEquals(interpolated.get(new TestNameCoordinate("TEST2"), TestEnum.ENUM2), 42.0, DOUBLE_COMPARISON_TOLERANCE);
+        assertEquals(interpolated.get(new TestNameCoordinate("TEST1"), TestEnum.ENUM1), 2.0,
+                DOUBLE_COMPARISON_TOLERANCE);
+        assertEquals(interpolated.get(new TestNameCoordinate("TEST2"), TestEnum.ENUM1), 2.5,
+                DOUBLE_COMPARISON_TOLERANCE);
+        assertEquals(interpolated.get(new TestNameCoordinate("TEST1"), TestEnum.ENUM2), 2.0,
+                DOUBLE_COMPARISON_TOLERANCE);
+        assertEquals(interpolated.get(new TestNameCoordinate("TEST2"), TestEnum.ENUM2), 42.0,
+                DOUBLE_COMPARISON_TOLERANCE);
 
     }
 
@@ -85,31 +89,37 @@ public class InterpolationAtTest {
         testTenosor = getTensorThreeCoordinates();
 
         Tensor<Double> interpolated = Tensorics.from(testTenosor).reduce(ComparableCoordinate.class)
-                .byInterpolatedSlicingAt(COORDINATE_BEFORE_THE_FIRST)
-                .interpolatingWith(new TestInterpolation());
+                .byInterpolatedSlicingAt(COORDINATE_BEFORE_THE_FIRST).interpolatingWith(new TestInterpolation());
 
         assertEquals(BIG_TENSOR_PROPER_SLICE_SIZE, interpolated.shape().positionSet().size());
 
-        assertEquals(interpolated.get(new TestNameCoordinate("TEST1"), TestEnum.ENUM1), -1.0, DOUBLE_COMPARISON_TOLERANCE);
-        assertEquals(interpolated.get(new TestNameCoordinate("TEST2"), TestEnum.ENUM1), -2.0, DOUBLE_COMPARISON_TOLERANCE);
-        assertEquals(interpolated.get(new TestNameCoordinate("TEST1"), TestEnum.ENUM2), -1.0, DOUBLE_COMPARISON_TOLERANCE);
-        assertEquals(interpolated.get(new TestNameCoordinate("TEST2"), TestEnum.ENUM2), -81.0, DOUBLE_COMPARISON_TOLERANCE);
+        assertEquals(interpolated.get(new TestNameCoordinate("TEST1"), TestEnum.ENUM1), -1.0,
+                DOUBLE_COMPARISON_TOLERANCE);
+        assertEquals(interpolated.get(new TestNameCoordinate("TEST2"), TestEnum.ENUM1), -2.0,
+                DOUBLE_COMPARISON_TOLERANCE);
+        assertEquals(interpolated.get(new TestNameCoordinate("TEST1"), TestEnum.ENUM2), -1.0,
+                DOUBLE_COMPARISON_TOLERANCE);
+        assertEquals(interpolated.get(new TestNameCoordinate("TEST2"), TestEnum.ENUM2), -81.0,
+                DOUBLE_COMPARISON_TOLERANCE);
     }
-    
+
     @Test
     public void extrapolateValuesAfterTheLastByInterpolation() {
         testTenosor = getTensorThreeCoordinates();
 
         Tensor<Double> interpolated = Tensorics.from(testTenosor).reduce(ComparableCoordinate.class)
-                .byInterpolatedSlicingAt(COORDINATE_AFTER_THE_LAST)
-                .interpolatingWith(new TestInterpolation());
+                .byInterpolatedSlicingAt(COORDINATE_AFTER_THE_LAST).interpolatingWith(new TestInterpolation());
 
         assertEquals(BIG_TENSOR_PROPER_SLICE_SIZE, interpolated.shape().positionSet().size());
 
-        assertEquals(interpolated.get(new TestNameCoordinate("TEST1"), TestEnum.ENUM1), 1.75, DOUBLE_COMPARISON_TOLERANCE);
-        assertEquals(interpolated.get(new TestNameCoordinate("TEST2"), TestEnum.ENUM1), 23.9, DOUBLE_COMPARISON_TOLERANCE);
-        assertEquals(interpolated.get(new TestNameCoordinate("TEST1"), TestEnum.ENUM2), 14.0, DOUBLE_COMPARISON_TOLERANCE);
-        assertEquals(interpolated.get(new TestNameCoordinate("TEST2"), TestEnum.ENUM2), 0.5, DOUBLE_COMPARISON_TOLERANCE);
+        assertEquals(interpolated.get(new TestNameCoordinate("TEST1"), TestEnum.ENUM1), 1.75,
+                DOUBLE_COMPARISON_TOLERANCE);
+        assertEquals(interpolated.get(new TestNameCoordinate("TEST2"), TestEnum.ENUM1), 23.9,
+                DOUBLE_COMPARISON_TOLERANCE);
+        assertEquals(interpolated.get(new TestNameCoordinate("TEST1"), TestEnum.ENUM2), 14.0,
+                DOUBLE_COMPARISON_TOLERANCE);
+        assertEquals(interpolated.get(new TestNameCoordinate("TEST2"), TestEnum.ENUM2), 0.5,
+                DOUBLE_COMPARISON_TOLERANCE);
     }
 
     @Test

--- a/src/test/org/tensorics/core/resolve/BinaryPredicateExpressionTest.java
+++ b/src/test/org/tensorics/core/resolve/BinaryPredicateExpressionTest.java
@@ -20,7 +20,6 @@
 
 package org.tensorics.core.resolve;
 
-
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -70,6 +69,7 @@ public class BinaryPredicateExpressionTest {
 
         assertFalse(falseResult);
     }
+
     @Test
     public void testIsLessThanForIterableExpressions() throws Exception {
 

--- a/src/test/org/tensorics/core/resolve/DeferredTensoricCalculationTest.java
+++ b/src/test/org/tensorics/core/resolve/DeferredTensoricCalculationTest.java
@@ -2,7 +2,7 @@
  /*******************************************************************************
  *
  * This file is part of tensorics.
- * 
+ *
  * Copyright (c) 2008-2011, CERN. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  ******************************************************************************/
 // @formatter:on
 package org.tensorics.core.resolve;
@@ -77,7 +77,7 @@ public class DeferredTensoricCalculationTest {
 
             @Override
             protected Expression<Tensor<Double>> describe() {
-                return ResolvedExpression.of(Tensorics.zeroDimensionalOf(0.4));
+                return ResolvedExpression.of(Tensorics.scalarOf(0.4));
             }
         });
         assertEquals(0.4, result.get(), 0.00001);

--- a/src/test/org/tensorics/core/tensor/CoordinatesTest.java
+++ b/src/test/org/tensorics/core/tensor/CoordinatesTest.java
@@ -104,7 +104,7 @@ public class CoordinatesTest {
         assertThat(result).containsExactlyInAnyOrder(IA.class, IB.class);
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void parentClassObjectIntersection() {
         ImmutableSet<Class<?>> leftCoordinates = ImmutableSet.of(A.class, B.class);
         ImmutableSet<Class<?>> rightCoordinates = ImmutableSet.of(Object.class);

--- a/src/test/org/tensorics/core/tensor/ImmutableScalarTest.java
+++ b/src/test/org/tensorics/core/tensor/ImmutableScalarTest.java
@@ -11,105 +11,104 @@ import org.junit.rules.ExpectedException;
 
 public class ImmutableScalarTest {
 
-	private static final String A_COORDINATE = "A Coordinate";
-	private static final Position A_CONTEXT = Position.of(A_COORDINATE);
-	private static final String A_VALUE = "aValue";
-	private ImmutableScalar<String> scalar;
+    private static final String A_COORDINATE = "A Coordinate";
+    private static final Position A_CONTEXT = Position.of(A_COORDINATE);
+    private static final String A_VALUE = "aValue";
+    private ImmutableScalar<String> scalar;
 
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
-	@Before
-	public void setUp() {
-		scalar = ImmutableScalar.of(A_VALUE);
-	}
+    @Before
+    public void setUp() {
+        scalar = ImmutableScalar.of(A_VALUE);
+    }
 
-	@Test
-	public void simpleScalar() {
-		assertThat(scalar.value()).isEqualTo(A_VALUE);
-	}
+    @Test
+    public void simpleScalar() {
+        assertThat(scalar.value()).isEqualTo(A_VALUE);
+    }
 
-	@Test
-	public void valueIsReturnedThroughTensorGet() {
-		assertThat(scalar.get()).isEqualTo(A_VALUE);
-	}
+    @Test
+    public void valueIsReturnedThroughTensorGet() {
+        assertThat(scalar.get()).isEqualTo(A_VALUE);
+    }
 
-	@Test
-	public void valueIsReturnedThroughTensorGetPosition() {
-		assertThat(scalar.get(Position.empty())).isEqualTo(A_VALUE);
-	}
+    @Test
+    public void valueIsReturnedThroughTensorGetPosition() {
+        assertThat(scalar.get(Position.empty())).isEqualTo(A_VALUE);
+    }
 
-	@Test
-	public void nullPositionThrowsNpe() {
-		thrown.expect(NullPointerException.class);
-		thrown.expectMessage("position");
+    @Test
+    public void nullPositionThrowsNpe() {
+        thrown.expect(NullPointerException.class);
+        thrown.expectMessage("position");
 
-		scalar.get((Position) null);
-	}
+        scalar.get((Position) null);
+    }
 
-	@Test
-	public void nullCoordinatesThrowsNpe() {
-		thrown.expect(NullPointerException.class);
-		thrown.expectMessage("coordinates");
+    @Test
+    public void nullCoordinatesThrowsNpe() {
+        thrown.expect(NullPointerException.class);
+        thrown.expectMessage("coordinates");
 
-		scalar.get((Object[]) null);
-	}
+        scalar.get((Object[]) null);
+    }
 
-	@Test
-	public void invalidCoordinatesArrayThrows() {
-		thrown.expect(NoSuchElementException.class);
-		thrown.expectMessage("requested coordinates");
+    @Test
+    public void invalidCoordinatesArrayThrows() {
+        thrown.expect(NoSuchElementException.class);
+        thrown.expectMessage("requested coordinates");
 
-		scalar.get("invalidCoordinate");
-	}
+        scalar.get("invalidCoordinate");
+    }
 
-	@Test
-	public void invalidPositionThrows() {
-		thrown.expect(NoSuchElementException.class);
-		thrown.expectMessage("requested position");
+    @Test
+    public void invalidPositionThrows() {
+        thrown.expect(NoSuchElementException.class);
+        thrown.expectMessage("requested position");
 
-		scalar.get(Position.of("InvalidCorrdinate"));
-	}
+        scalar.get(Position.of("InvalidCorrdinate"));
+    }
 
-	@Test
-	public void initialContextIsEmpty() {
-		assertThat(scalar.context()).isEqualTo(Position.empty());
-	}
+    @Test
+    public void initialContextIsEmpty() {
+        assertThat(scalar.context()).isEqualTo(Position.empty());
+    }
 
-	@Test
-	public void contextChangeWorks() {
-		ImmutableScalar<String> newScalar = scalar.withContext(A_CONTEXT);
-		assertThat(newScalar.context()).isEqualTo(A_CONTEXT);
-	}
+    @Test
+    public void contextChangeWorks() {
+        ImmutableScalar<String> newScalar = scalar.withContext(A_CONTEXT);
+        assertThat(newScalar.context()).isEqualTo(A_CONTEXT);
+    }
 
-	@Test
-	public void contextCoordinatesChangeWorks() {
-		ImmutableScalar<String> newScalar = scalar.withContext(A_COORDINATE);
-		assertThat(newScalar.context()).isEqualTo(A_CONTEXT);
-	}
+    @Test
+    public void contextCoordinatesChangeWorks() {
+        ImmutableScalar<String> newScalar = scalar.withContext(A_COORDINATE);
+        assertThat(newScalar.context()).isEqualTo(A_CONTEXT);
+    }
 
-	
-	@Test
-	public void nullValueThrowsNpe() {
-		thrown.expect(NullPointerException.class);
-		thrown.expectMessage("value");
+    @Test
+    public void nullValueThrowsNpe() {
+        thrown.expect(NullPointerException.class);
+        thrown.expectMessage("value");
 
-		ImmutableScalar.of(null);
-	}
+        ImmutableScalar.of(null);
+    }
 
-	@Test
-	public void nullContextThrowsNpe() {
-		thrown.expect(NullPointerException.class);
-		thrown.expectMessage("context");
+    @Test
+    public void nullContextThrowsNpe() {
+        thrown.expect(NullPointerException.class);
+        thrown.expectMessage("context");
 
-		scalar.withContext((Position) null);
-	}
+        scalar.withContext((Position) null);
+    }
 
-	@Test
-	public void nullContextCoordinatesThrowsNpe() {
-		thrown.expect(NullPointerException.class);
-		thrown.expectMessage("coordinates");
+    @Test
+    public void nullContextCoordinatesThrowsNpe() {
+        thrown.expect(NullPointerException.class);
+        thrown.expectMessage("coordinates");
 
-		scalar.withContext((Object[]) null);
-	}
+        scalar.withContext((Object[]) null);
+    }
 }

--- a/src/test/org/tensorics/core/tensor/ImmutableScalarTest.java
+++ b/src/test/org/tensorics/core/tensor/ImmutableScalarTest.java
@@ -1,0 +1,115 @@
+package org.tensorics.core.tensor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.NoSuchElementException;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ImmutableScalarTest {
+
+	private static final String A_COORDINATE = "A Coordinate";
+	private static final Position A_CONTEXT = Position.of(A_COORDINATE);
+	private static final String A_VALUE = "aValue";
+	private ImmutableScalar<String> scalar;
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Before
+	public void setUp() {
+		scalar = ImmutableScalar.of(A_VALUE);
+	}
+
+	@Test
+	public void simpleScalar() {
+		assertThat(scalar.value()).isEqualTo(A_VALUE);
+	}
+
+	@Test
+	public void valueIsReturnedThroughTensorGet() {
+		assertThat(scalar.get()).isEqualTo(A_VALUE);
+	}
+
+	@Test
+	public void valueIsReturnedThroughTensorGetPosition() {
+		assertThat(scalar.get(Position.empty())).isEqualTo(A_VALUE);
+	}
+
+	@Test
+	public void nullPositionThrowsNpe() {
+		thrown.expect(NullPointerException.class);
+		thrown.expectMessage("position");
+
+		scalar.get((Position) null);
+	}
+
+	@Test
+	public void nullCoordinatesThrowsNpe() {
+		thrown.expect(NullPointerException.class);
+		thrown.expectMessage("coordinates");
+
+		scalar.get((Object[]) null);
+	}
+
+	@Test
+	public void invalidCoordinatesArrayThrows() {
+		thrown.expect(NoSuchElementException.class);
+		thrown.expectMessage("requested coordinates");
+
+		scalar.get("invalidCoordinate");
+	}
+
+	@Test
+	public void invalidPositionThrows() {
+		thrown.expect(NoSuchElementException.class);
+		thrown.expectMessage("requested position");
+
+		scalar.get(Position.of("InvalidCorrdinate"));
+	}
+
+	@Test
+	public void initialContextIsEmpty() {
+		assertThat(scalar.context()).isEqualTo(Position.empty());
+	}
+
+	@Test
+	public void contextChangeWorks() {
+		ImmutableScalar<String> newScalar = scalar.withContext(A_CONTEXT);
+		assertThat(newScalar.context()).isEqualTo(A_CONTEXT);
+	}
+
+	@Test
+	public void contextCoordinatesChangeWorks() {
+		ImmutableScalar<String> newScalar = scalar.withContext(A_COORDINATE);
+		assertThat(newScalar.context()).isEqualTo(A_CONTEXT);
+	}
+
+	
+	@Test
+	public void nullValueThrowsNpe() {
+		thrown.expect(NullPointerException.class);
+		thrown.expectMessage("value");
+
+		ImmutableScalar.of(null);
+	}
+
+	@Test
+	public void nullContextThrowsNpe() {
+		thrown.expect(NullPointerException.class);
+		thrown.expectMessage("context");
+
+		scalar.withContext((Position) null);
+	}
+
+	@Test
+	public void nullContextCoordinatesThrowsNpe() {
+		thrown.expect(NullPointerException.class);
+		thrown.expectMessage("coordinates");
+
+		scalar.withContext((Object[]) null);
+	}
+}

--- a/src/test/org/tensorics/core/tensor/ImmutableTensorTest.java
+++ b/src/test/org/tensorics/core/tensor/ImmutableTensorTest.java
@@ -85,7 +85,7 @@ public class ImmutableTensorTest {
 
     @Test
     public void testZeroDimensionTensor() {
-        Tensor<Double> asZeroDimension = Tensorics.zeroDimensionalOf(2.4);
+        Tensor<Double> asZeroDimension = Tensorics.scalarOf(2.4);
         assertEquals(2.4, asZeroDimension.get(), 0.0);
         assertEquals(0, asZeroDimension.shape().dimensionality());
         assertEquals(1, asZeroDimension.shape().size());

--- a/src/test/org/tensorics/core/tensor/PositionTest.java
+++ b/src/test/org/tensorics/core/tensor/PositionTest.java
@@ -31,51 +31,51 @@ import com.google.common.collect.ImmutableSet;
 
 public class PositionTest {
 
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
-	private static final Position POS_A = Position.of("A");
+    private static final Position POS_A = Position.of("A");
 
-	@Test
-	public void coordinatesContainPositionThrows() {
-		thrown.expect(IllegalArgumentException.class);
-		thrown.expectMessage("A position is contained");
-		Position.of(POS_A);
-	}
+    @Test
+    public void coordinatesContainPositionThrows() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("A position is contained");
+        Position.of(POS_A);
+    }
 
-	@Test
-	public void assertConsistentWithCorrectSet() {
-		assertConsistentDimensions(POS_A, ImmutableSet.of(String.class));
-	}
+    @Test
+    public void assertConsistentWithCorrectSet() {
+        assertConsistentDimensions(POS_A, ImmutableSet.of(String.class));
+    }
 
-	@Test
-	public void assertConsistentWithWrongSetThrows() {
-		thrown.expect(IllegalArgumentException.class);
+    @Test
+    public void assertConsistentWithWrongSetThrows() {
+        thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage("assignable");
-		assertConsistentDimensions(POS_A, ImmutableSet.of(Integer.class));
-	}
+        assertConsistentDimensions(POS_A, ImmutableSet.of(Integer.class));
+    }
 
-	@Test
-	public void positionOfSameTypeAndNonEqualThrow() {
-		expectUniqueDimensionsException();
-		Position.of("A", "B");
-	}
-	
-	@Test
-	public void positionOfSetSameTypeThrow() {
-		expectUniqueDimensionsException();
-		Position.of(ImmutableSet.of("A", "B"));
-	}
+    @Test
+    public void positionOfSameTypeAndNonEqualThrow() {
+        expectUniqueDimensionsException();
+        Position.of("A", "B");
+    }
 
-	@Test
-	public void positionOfSameTypeAndSameValueThrow() {
-		expectUniqueDimensionsException();
-		Position.of("A", "A");
-	}
+    @Test
+    public void positionOfSetSameTypeThrow() {
+        expectUniqueDimensionsException();
+        Position.of(ImmutableSet.of("A", "B"));
+    }
 
-	private void expectUniqueDimensionsException() {
-		thrown.expect(IllegalArgumentException.class);
-		thrown.expectMessage("unique dimensions");
-	}
+    @Test
+    public void positionOfSameTypeAndSameValueThrow() {
+        expectUniqueDimensionsException();
+        Position.of("A", "A");
+    }
+
+    private void expectUniqueDimensionsException() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("unique dimensions");
+    }
 
 }

--- a/src/test/org/tensorics/core/tensor/TensorEqualityTest.java
+++ b/src/test/org/tensorics/core/tensor/TensorEqualityTest.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2017 European Organisation for Nuclear Research (CERN), All Rights Reserved.
+ */
+
+package org.tensorics.core.tensor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.tensorics.core.lang.Tensorics.scalarOf;
+
+import java.util.Collections;
+
+import org.junit.Test;
+import org.tensorics.core.tensor.ImmutableTensor.Builder;
+
+public class TensorEqualityTest {
+
+    private static final String A_VALUE = "aValue";
+
+    @Test
+    public void scalarIsEqualToZerodimTensor() {
+        assertThat(scalarOf(A_VALUE)).isEqualTo(zeroDimensionalOf(A_VALUE));
+    }
+
+    @Test
+    public void zerodimTensorIsEqualToScalar() {
+        assertThat(zeroDimensionalOf(A_VALUE)).isEqualTo(scalarOf(A_VALUE));
+    }
+
+    @Test
+    public void differentContextsAreNotEqual() {
+        assertThat(zeroDimensionalOf(A_VALUE)).isNotEqualTo(scalarOf(A_VALUE).withContext("aCoord"));
+    }
+
+    private static <T> Tensor<T> zeroDimensionalOf(T value) {
+        Builder<T> builder = ImmutableTensor.builder(Collections.<Class<?>> emptySet());
+        builder.at(Position.empty()).put(value);
+        return builder.build();
+    }
+
+}

--- a/src/test/org/tensorics/core/tensor/lang/BroadcastAllBroadcastingStrategyTest.java
+++ b/src/test/org/tensorics/core/tensor/lang/BroadcastAllBroadcastingStrategyTest.java
@@ -2,7 +2,7 @@
  /*******************************************************************************
  *
  * This file is part of tensorics.
- * 
+ *
  * Copyright (c) 2008-2011, CERN. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  ******************************************************************************/
 // @formatter:on
 package org.tensorics.core.tensor.lang;
@@ -40,7 +40,7 @@ import org.tensorics.core.tensor.options.BroadcastingStrategy;
 
 public class BroadcastAllBroadcastingStrategyTest {
 
-    private static final Tensor<Double> ZERO_DIMENSIONAL_ZERO = Tensorics.zeroDimensionalOf(0.0);
+    private static final Tensor<Double> ZERO_DIMENSIONAL_ZERO = Tensorics.scalarOf(0.0);
 
     private static final Position POS_A = Position.of("A");
     private static final Position POS_B = Position.of("B");

--- a/src/test/org/tensorics/core/tensor/operations/TensorInternalsTest.java
+++ b/src/test/org/tensorics/core/tensor/operations/TensorInternalsTest.java
@@ -18,30 +18,30 @@ import com.google.common.collect.ImmutableMap;
 
 public class TensorInternalsTest {
 
-	private final static Shape SHAPE_TO_RETURN = Shape.zeroDimensional();
-	private final static String VALUE_TO_RETURN = "aValue";
-	private final static Map<Position, String> MAP_TO_RETURN = ImmutableMap.of(Position.empty(), VALUE_TO_RETURN);
+    private final static Shape SHAPE_TO_RETURN = Shape.zeroDimensional();
+    private final static String VALUE_TO_RETURN = "aValue";
+    private final static Map<Position, String> MAP_TO_RETURN = ImmutableMap.of(Position.empty(), VALUE_TO_RETURN);
 
-	@Test
-	public void mapFromCallsAsMapFromMapableTensor() {
-		@SuppressWarnings("unchecked")
-		MappableTensor<String> mapableTensor = mock(MappableTensor.class);
-		when(mapableTensor.asMap()).thenReturn(MAP_TO_RETURN);
+    @Test
+    public void mapFromCallsAsMapFromMapableTensor() {
+        @SuppressWarnings("unchecked")
+        MappableTensor<String> mapableTensor = mock(MappableTensor.class);
+        when(mapableTensor.asMap()).thenReturn(MAP_TO_RETURN);
 
-		Map<Position, String> returned = TensorInternals.mapFrom(mapableTensor);
-		assertThat(returned).isEqualTo(MAP_TO_RETURN);
-		verify(mapableTensor, times(1)).asMap();
-	}
-	
-	@Test
-	public void mapIsConstructedFromShape() {
-		@SuppressWarnings("unchecked")
-		Tensor<String> tensor = mock(Tensor.class);
-		when(tensor.shape()).thenReturn(SHAPE_TO_RETURN);
-		when(tensor.get(Position.empty())).thenReturn(VALUE_TO_RETURN);
+        Map<Position, String> returned = TensorInternals.mapFrom(mapableTensor);
+        assertThat(returned).isEqualTo(MAP_TO_RETURN);
+        verify(mapableTensor, times(1)).asMap();
+    }
 
-		Map<Position, String> returned = TensorInternals.mapFrom(tensor);
-		assertThat(returned).isEqualTo(MAP_TO_RETURN);
-	}
+    @Test
+    public void mapIsConstructedFromShape() {
+        @SuppressWarnings("unchecked")
+        Tensor<String> tensor = mock(Tensor.class);
+        when(tensor.shape()).thenReturn(SHAPE_TO_RETURN);
+        when(tensor.get(Position.empty())).thenReturn(VALUE_TO_RETURN);
+
+        Map<Position, String> returned = TensorInternals.mapFrom(tensor);
+        assertThat(returned).isEqualTo(MAP_TO_RETURN);
+    }
 
 }

--- a/src/test/org/tensorics/core/tensorbacked/AbstractTensorbackedTest.java
+++ b/src/test/org/tensorics/core/tensorbacked/AbstractTensorbackedTest.java
@@ -21,95 +21,98 @@ import org.tensorics.core.tensor.operations.TensorInternals;
 import org.tensorics.core.tensorbacked.annotation.Dimensions;
 
 public class AbstractTensorbackedTest {
-	public interface FirstCoordinateInterface {
-		/* marker interface */
-	}
+    public interface FirstCoordinateInterface {
+        /* marker interface */
+    }
 
-	public enum FirstCoordinate implements FirstCoordinateInterface {
-		FIRST_1, FIRST_2, FIRST_3;
-	}
+    public enum FirstCoordinate implements FirstCoordinateInterface {
+        FIRST_1,
+        FIRST_2,
+        FIRST_3;
+    }
 
-	public enum SecondCoordinate {
-		SECOND_1, SECOND_2;
-	}
+    public enum SecondCoordinate {
+        SECOND_1,
+        SECOND_2;
+    }
 
-	@Dimensions({ FirstCoordinate.class, SecondCoordinate.class })
-	public static class LeafClassTensorbacked extends AbstractTensorbacked<Double> {
-		private static final long serialVersionUID = 1L;
+    @Dimensions({ FirstCoordinate.class, SecondCoordinate.class })
+    public static class LeafClassTensorbacked extends AbstractTensorbacked<Double> {
+        private static final long serialVersionUID = 1L;
 
-		public LeafClassTensorbacked(Tensor<Double> tensor) {
-			super(tensor);
-		}
-	}
+        public LeafClassTensorbacked(Tensor<Double> tensor) {
+            super(tensor);
+        }
+    }
 
-	@Dimensions({ FirstCoordinateInterface.class, SecondCoordinate.class })
-	public static class InterfaceTensorbacked extends AbstractTensorbacked<Double> {
-		private static final long serialVersionUID = 1L;
+    @Dimensions({ FirstCoordinateInterface.class, SecondCoordinate.class })
+    public static class InterfaceTensorbacked extends AbstractTensorbacked<Double> {
+        private static final long serialVersionUID = 1L;
 
-		public InterfaceTensorbacked(Tensor<Double> tensor) {
-			super(tensor);
-		}
-	}
+        public InterfaceTensorbacked(Tensor<Double> tensor) {
+            super(tensor);
+        }
+    }
 
-	private Tensor<Double> buildTensorFor(Class<?>... dimensions) {
-		TensorBuilder<Double> builder = Tensorics.builder(dimensions);
-		builder.putAt(11.0, FirstCoordinate.FIRST_1, SecondCoordinate.SECOND_1);
-		builder.putAt(12.0, FirstCoordinate.FIRST_1, SecondCoordinate.SECOND_2);
-		builder.putAt(21.0, FirstCoordinate.FIRST_2, SecondCoordinate.SECOND_1);
-		return builder.build();
-	}
+    private Tensor<Double> buildTensorFor(Class<?>... dimensions) {
+        TensorBuilder<Double> builder = Tensorics.builder(dimensions);
+        builder.putAt(11.0, FirstCoordinate.FIRST_1, SecondCoordinate.SECOND_1);
+        builder.putAt(12.0, FirstCoordinate.FIRST_1, SecondCoordinate.SECOND_2);
+        builder.putAt(21.0, FirstCoordinate.FIRST_2, SecondCoordinate.SECOND_1);
+        return builder.build();
+    }
 
-	private final Tensor<Double> leafClassTensor = buildTensorFor(FirstCoordinate.class, SecondCoordinate.class);
-	private final Tensor<Double> interfaceTensor = buildTensorFor(FirstCoordinateInterface.class,
-			SecondCoordinate.class);
+    private final Tensor<Double> leafClassTensor = buildTensorFor(FirstCoordinate.class, SecondCoordinate.class);
+    private final Tensor<Double> interfaceTensor = buildTensorFor(FirstCoordinateInterface.class,
+            SecondCoordinate.class);
 
-	@Test
-	public void canConstructLeafClassTensorbackedFromLeafClassTensor() {
-		LeafClassTensorbacked tb = new LeafClassTensorbacked(leafClassTensor);
-		assertEquals(TensorInternals.mapFrom(tb.tensor()), TensorInternals.mapFrom(leafClassTensor));
-		assertEquals(TensorbackedInternals.dimensionsOf(LeafClassTensorbacked.class),
-				tb.tensor().shape().dimensionSet());
-	}
+    @Test
+    public void canConstructLeafClassTensorbackedFromLeafClassTensor() {
+        LeafClassTensorbacked tb = new LeafClassTensorbacked(leafClassTensor);
+        assertEquals(TensorInternals.mapFrom(tb.tensor()), TensorInternals.mapFrom(leafClassTensor));
+        assertEquals(TensorbackedInternals.dimensionsOf(LeafClassTensorbacked.class),
+                tb.tensor().shape().dimensionSet());
+    }
 
-	@Test(expected = IllegalArgumentException.class)
-	public void canNotConstructLeafClassTensorbackedFromInterfaceClassTensor() {
-		LeafClassTensorbacked tb = new LeafClassTensorbacked(interfaceTensor);
-		assertEquals(Tensorics.mapFrom(tb.tensor()), TensorInternals.mapFrom(interfaceTensor));
-	}
+    @Test(expected = IllegalArgumentException.class)
+    public void canNotConstructLeafClassTensorbackedFromInterfaceClassTensor() {
+        LeafClassTensorbacked tb = new LeafClassTensorbacked(interfaceTensor);
+        assertEquals(Tensorics.mapFrom(tb.tensor()), TensorInternals.mapFrom(interfaceTensor));
+    }
 
-	public void canConstructInterfaceTensorbackedFromLeafClassTensor() {
-		InterfaceTensorbacked tb = new InterfaceTensorbacked(leafClassTensor);
-		assertEquals(Tensorics.mapFrom(tb.tensor()), TensorInternals.mapFrom(leafClassTensor));
-		assertEquals(TensorbackedInternals.dimensionsOf(InterfaceTensorbacked.class),
-				tb.tensor().shape().dimensionSet());
-	}
+    public void canConstructInterfaceTensorbackedFromLeafClassTensor() {
+        InterfaceTensorbacked tb = new InterfaceTensorbacked(leafClassTensor);
+        assertEquals(Tensorics.mapFrom(tb.tensor()), TensorInternals.mapFrom(leafClassTensor));
+        assertEquals(TensorbackedInternals.dimensionsOf(InterfaceTensorbacked.class),
+                tb.tensor().shape().dimensionSet());
+    }
 
-	@Test
-	public void canNotConstructInterfaceTensorbackedFromInterfaceClassTensor() {
-		InterfaceTensorbacked tb = new InterfaceTensorbacked(interfaceTensor);
-		assertEquals(Tensorics.mapFrom(tb.tensor()), TensorInternals.mapFrom(interfaceTensor));
-	}
+    @Test
+    public void canNotConstructInterfaceTensorbackedFromInterfaceClassTensor() {
+        InterfaceTensorbacked tb = new InterfaceTensorbacked(interfaceTensor);
+        assertEquals(Tensorics.mapFrom(tb.tensor()), TensorInternals.mapFrom(interfaceTensor));
+    }
 
-	@Test
-	public void interfaceTensorbackedCalculationTest() {
-		InterfaceTensorbacked tb = new InterfaceTensorbacked(interfaceTensor);
-		InterfaceTensorbacked result = DoubleTensorics.calculate(tb).plus(tb);
+    @Test
+    public void interfaceTensorbackedCalculationTest() {
+        InterfaceTensorbacked tb = new InterfaceTensorbacked(interfaceTensor);
+        InterfaceTensorbacked result = DoubleTensorics.calculate(tb).plus(tb);
 
-		assertResultOfCalculation(result);
-	}
+        assertResultOfCalculation(result);
+    }
 
-	@Test
-	public void leafClassTensorbackedCalculationTest() {
-		LeafClassTensorbacked tb = new LeafClassTensorbacked(leafClassTensor);
-		LeafClassTensorbacked result = DoubleTensorics.calculate(tb).plus(tb);
+    @Test
+    public void leafClassTensorbackedCalculationTest() {
+        LeafClassTensorbacked tb = new LeafClassTensorbacked(leafClassTensor);
+        LeafClassTensorbacked result = DoubleTensorics.calculate(tb).plus(tb);
 
-		assertResultOfCalculation(result);
-	}
+        assertResultOfCalculation(result);
+    }
 
-	private void assertResultOfCalculation(AbstractTensorbacked<?> result) {
-		Assertions.assertThat(result.tensor().get(FIRST_1, SECOND_1)).isEqualTo(valueOf(22));
-		Assertions.assertThat(result.tensor().get(FIRST_1, SECOND_2)).isEqualTo(valueOf(24));
-		Assertions.assertThat(result.tensor().get(FIRST_2, SECOND_1)).isEqualTo(valueOf(42));
-	}
+    private void assertResultOfCalculation(AbstractTensorbacked<?> result) {
+        Assertions.assertThat(result.tensor().get(FIRST_1, SECOND_1)).isEqualTo(valueOf(22));
+        Assertions.assertThat(result.tensor().get(FIRST_1, SECOND_2)).isEqualTo(valueOf(24));
+        Assertions.assertThat(result.tensor().get(FIRST_2, SECOND_1)).isEqualTo(valueOf(42));
+    }
 
 }

--- a/src/test/org/tensorics/core/tensorbacked/TensorbackedBuilderTest.java
+++ b/src/test/org/tensorics/core/tensorbacked/TensorbackedBuilderTest.java
@@ -39,119 +39,119 @@ import com.google.common.collect.Iterables;
 
 public class TensorbackedBuilderTest {
 
-	private static final double TESTVALUE_1_0 = 1.0;
-	private static final Bpm BPM_A = new Bpm("A");
-	private static final Position POS_A_H = Position.of(BPM_A, Plane.H);
+    private static final double TESTVALUE_1_0 = 1.0;
+    private static final Bpm BPM_A = new Bpm("A");
+    private static final Position POS_A_H = Position.of(BPM_A, Plane.H);
 
-	@Test
-	public void emptyTensorbackedHasCorrectDimensionality() {
-		assertThat(Tensorics.dimensionalityOf(emptyOrbit()), equalTo(2));
-	}
+    @Test
+    public void emptyTensorbackedHasCorrectDimensionality() {
+        assertThat(Tensorics.dimensionalityOf(emptyOrbit()), equalTo(2));
+    }
 
-	@Test
-	public void emptyTensorHasSizeZero() {
-		assertThat(Tensorics.sizeOf(emptyOrbit()), equalTo(0));
-	}
+    @Test
+    public void emptyTensorHasSizeZero() {
+        assertThat(Tensorics.sizeOf(emptyOrbit()), equalTo(0));
+    }
 
-	@Test(expected = IllegalArgumentException.class)
-	public void putInsufficientCoordinateThrows() {
-		newBuilder().at(BPM_A).put(1.0);
-	}
+    @Test(expected = IllegalArgumentException.class)
+    public void putInsufficientCoordinateThrows() {
+        newBuilder().at(BPM_A).put(1.0);
+    }
 
-	@Test
-	public void putOneCorrectValueWorks() {
-		TensorbackedBuilder<Double, SinglebeamOrbit> builder = newBuilder();
-		builder.at(BPM_A, Plane.H).put(1.0);
-		SinglebeamOrbit orbit = builder.build();
-		assertThat(Tensorics.sizeOf(orbit), equalTo(1));
-	}
+    @Test
+    public void putOneCorrectValueWorks() {
+        TensorbackedBuilder<Double, SinglebeamOrbit> builder = newBuilder();
+        builder.at(BPM_A, Plane.H).put(1.0);
+        SinglebeamOrbit orbit = builder.build();
+        assertThat(Tensorics.sizeOf(orbit), equalTo(1));
+    }
 
-	@Test(expected = IllegalArgumentException.class)
-	public void putAtOnePositionWithWrongCoordinatesThrows() {
-		newBuilder().at(Position.of(BPM_A)).put(TESTVALUE_1_0);
-	}
+    @Test(expected = IllegalArgumentException.class)
+    public void putAtOnePositionWithWrongCoordinatesThrows() {
+        newBuilder().at(Position.of(BPM_A)).put(TESTVALUE_1_0);
+    }
 
-	@Test
-	public void putOneAtPositionHasCorrectSize() {
-		assertThat(Tensorics.sizeOf(oneValuePosAH()), equalTo(1));
-	}
+    @Test
+    public void putOneAtPositionHasCorrectSize() {
+        assertThat(Tensorics.sizeOf(oneValuePosAH()), equalTo(1));
+    }
 
-	@Test
-	public void putOneAtPositionHasCorrectValue() {
-		assertThat(oneValuePosAH().tensor().get(POS_A_H), equalTo(TESTVALUE_1_0));
-	}
+    @Test
+    public void putOneAtPositionHasCorrectValue() {
+        assertThat(oneValuePosAH().tensor().get(POS_A_H), equalTo(TESTVALUE_1_0));
+    }
 
-	@Test
-	public void putOneValueByCoordinatesHasCorrectValue() {
-		assertThat(oneValueCoordinatesAH().tensor().get(POS_A_H), equalTo(TESTVALUE_1_0));
-	}
+    @Test
+    public void putOneValueByCoordinatesHasCorrectValue() {
+        assertThat(oneValueCoordinatesAH().tensor().get(POS_A_H), equalTo(TESTVALUE_1_0));
+    }
 
-	@Test
-	public void oneValueCoordinatesEqualsOneValuePos() {
-		assertThat(oneValueCoordinatesAH(), equalTo(oneValuePosAH()));
-	}
+    @Test
+    public void oneValueCoordinatesEqualsOneValuePos() {
+        assertThat(oneValueCoordinatesAH(), equalTo(oneValuePosAH()));
+    }
 
-	@Test(expected = NullPointerException.class)
-	public void putNullEntryThrows() {
-		java.util.Map.Entry<Position, Double> toPut = null;
-		newBuilder().put(toPut);
-	}
+    @Test(expected = NullPointerException.class)
+    public void putNullEntryThrows() {
+        java.util.Map.Entry<Position, Double> toPut = null;
+        newBuilder().put(toPut);
+    }
 
-	@Test
-	public void putOneEntryIsEqualToOriginal() {
-		TensorbackedBuilder<Double, SinglebeamOrbit> builder = newBuilder();
-		builder.put(Iterables.getFirst(Tensorics.mapFrom(oneValuePosAH().tensor()).entrySet(), null));
-		assertThat(builder.build(), equalTo(oneValuePosAH()));
-	}
+    @Test
+    public void putOneEntryIsEqualToOriginal() {
+        TensorbackedBuilder<Double, SinglebeamOrbit> builder = newBuilder();
+        builder.put(Iterables.getFirst(Tensorics.mapFrom(oneValuePosAH().tensor()).entrySet(), null));
+        assertThat(builder.build(), equalTo(oneValuePosAH()));
+    }
 
-	@Test(expected = NullPointerException.class)
-	public void putNullEntriesThrows() {
-		Set<java.util.Map.Entry<Position, Double>> toPut = null;
-		newBuilder().putAll(toPut);
-	}
+    @Test(expected = NullPointerException.class)
+    public void putNullEntriesThrows() {
+        Set<java.util.Map.Entry<Position, Double>> toPut = null;
+        newBuilder().putAll(toPut);
+    }
 
-	@Test
-	public void putEmptyCollectionResultsInEmptyTensor() {
-		TensorbackedBuilder<Double, SinglebeamOrbit> builder = newBuilder();
-		builder.putAll(Collections.<java.util.Map.Entry<Position, Double>>emptySet());
-		assertThat(Tensorics.sizeOf(builder.build()), equalTo(0));
-	}
+    @Test
+    public void putEmptyCollectionResultsInEmptyTensor() {
+        TensorbackedBuilder<Double, SinglebeamOrbit> builder = newBuilder();
+        builder.putAll(Collections.<java.util.Map.Entry<Position, Double>> emptySet());
+        assertThat(Tensorics.sizeOf(builder.build()), equalTo(0));
+    }
 
-	@Test
-	public void copyByEntryEqualsToOriginal() {
-		assertThat(oneValuePosCopied(), equalTo(oneValuePosAH()));
-	}
+    @Test
+    public void copyByEntryEqualsToOriginal() {
+        assertThat(oneValuePosCopied(), equalTo(oneValuePosAH()));
+    }
 
-	@Test
-	public void copyByEntryEqualsHasCorrectSize() {
-		assertThat(Tensorics.sizeOf(oneValuePosCopied()), equalTo(1));
-	}
+    @Test
+    public void copyByEntryEqualsHasCorrectSize() {
+        assertThat(Tensorics.sizeOf(oneValuePosCopied()), equalTo(1));
+    }
 
-	private SinglebeamOrbit oneValuePosCopied() {
-		TensorbackedBuilder<Double, SinglebeamOrbit> builder = newBuilder();
-		builder.putAll(Tensorics.mapFrom(oneValuePosAH().tensor()).entrySet());
-		SinglebeamOrbit copiedOrbit = builder.build();
-		return copiedOrbit;
-	}
+    private SinglebeamOrbit oneValuePosCopied() {
+        TensorbackedBuilder<Double, SinglebeamOrbit> builder = newBuilder();
+        builder.putAll(Tensorics.mapFrom(oneValuePosAH().tensor()).entrySet());
+        SinglebeamOrbit copiedOrbit = builder.build();
+        return copiedOrbit;
+    }
 
-	private SinglebeamOrbit oneValueCoordinatesAH() {
-		TensorbackedBuilder<Double, SinglebeamOrbit> builder = newBuilder();
-		builder.at(POS_A_H.coordinates()).put(TESTVALUE_1_0);
-		return builder.build();
-	}
+    private SinglebeamOrbit oneValueCoordinatesAH() {
+        TensorbackedBuilder<Double, SinglebeamOrbit> builder = newBuilder();
+        builder.at(POS_A_H.coordinates()).put(TESTVALUE_1_0);
+        return builder.build();
+    }
 
-	private SinglebeamOrbit oneValuePosAH() {
-		TensorbackedBuilder<Double, SinglebeamOrbit> builder = newBuilder();
-		builder.at(POS_A_H).put(TESTVALUE_1_0);
-		return builder.build();
-	}
+    private SinglebeamOrbit oneValuePosAH() {
+        TensorbackedBuilder<Double, SinglebeamOrbit> builder = newBuilder();
+        builder.at(POS_A_H).put(TESTVALUE_1_0);
+        return builder.build();
+    }
 
-	private TensorbackedBuilder<Double, SinglebeamOrbit> newBuilder() {
-		return Tensorics.builderFor(SinglebeamOrbit.class);
-	}
+    private TensorbackedBuilder<Double, SinglebeamOrbit> newBuilder() {
+        return Tensorics.builderFor(SinglebeamOrbit.class);
+    }
 
-	private SinglebeamOrbit emptyOrbit() {
-		return newBuilder().build();
-	}
+    private SinglebeamOrbit emptyOrbit() {
+        return newBuilder().build();
+    }
 
 }

--- a/src/test/org/tensorics/core/testing/TestUtil.java
+++ b/src/test/org/tensorics/core/testing/TestUtil.java
@@ -72,8 +72,8 @@ public class TestUtil {
         throw new RuntimeException("Error while validating utility class.", e);
     }
 
-    private static void verifyInternalUtilityClass(final Class<?> clazz) throws NoSuchMethodException,
-            InstantiationException, IllegalAccessException, InvocationTargetException {
+    private static void verifyInternalUtilityClass(final Class<?> clazz)
+            throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
         verifyClassIsFinal(clazz);
         verifyPrivateConstructor(clazz);
         verifyAllMethodsStatic(clazz);
@@ -83,8 +83,8 @@ public class TestUtil {
         assertTrue("class must be final", Modifier.isFinal(clazz.getModifiers()));
     }
 
-    private static void verifyPrivateConstructor(final Class<?> clazz) throws NoSuchMethodException,
-            InstantiationException, IllegalAccessException, InvocationTargetException {
+    private static void verifyPrivateConstructor(final Class<?> clazz)
+            throws NoSuchMethodException, InstantiationException, IllegalAccessException, InvocationTargetException {
         assertEquals("There must be only one constructor", 1, clazz.getDeclaredConstructors().length);
         final Constructor<?> constructor = clazz.getDeclaredConstructor();
         if (constructor.isAccessible() || !Modifier.isPrivate(constructor.getModifiers())) {
@@ -101,8 +101,8 @@ public class TestUtil {
         }
     }
 
-    private static void callPrivateConstructor(final Constructor<?> constructor) throws InstantiationException,
-            IllegalAccessException, InvocationTargetException {
+    private static void callPrivateConstructor(final Constructor<?> constructor)
+            throws InstantiationException, IllegalAccessException, InvocationTargetException {
         constructor.setAccessible(true);
         constructor.newInstance();
         constructor.setAccessible(false);

--- a/src/test/org/tensorics/core/testing/lang/TensoricDoubleTestingSupportTest.java
+++ b/src/test/org/tensorics/core/testing/lang/TensoricDoubleTestingSupportTest.java
@@ -2,7 +2,7 @@
  /*******************************************************************************
  *
  * This file is part of tensorics.
- * 
+ *
  * Copyright (c) 2008-2011, CERN. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +16,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  ******************************************************************************/
 // @formatter:on
 
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 import org.tensorics.core.lang.Tensorics;
+import org.tensorics.core.tensor.Scalar;
 import org.tensorics.core.tensor.Tensor;
 
 public class TensoricDoubleTestingSupportTest extends TensoricDoubleTestingSupport {
@@ -61,12 +62,12 @@ public class TensoricDoubleTestingSupportTest extends TensoricDoubleTestingSuppo
         return Tensorics.<Double> builder().build();
     }
 
-    private Tensor<Double> zeroDotOne() {
-        return Tensorics.zeroDimensionalOf(0.1);
+    private Scalar<Double> zeroDotOne() {
+        return Tensorics.scalarOf(0.1);
     }
 
-    private Tensor<Double> zeroTensor() {
-        return Tensorics.zeroDimensionalOf(0.0);
+    private Scalar<Double> zeroTensor() {
+        return Tensorics.scalarOf(0.0);
     }
 
 }

--- a/src/test/org/tensorics/core/tree/PathWithoutMatchingNodeTest.java
+++ b/src/test/org/tensorics/core/tree/PathWithoutMatchingNodeTest.java
@@ -78,13 +78,13 @@ public class PathWithoutMatchingNodeTest {
 
         childCommon = mock(Node.class);
 
-        when(rootNode.getChildren()).thenAnswer((args)-> ImmutableList.<Node> of(child1, child2));
-        when(child1.getChildren()).thenAnswer((args)-> ImmutableList.<Node> of(child11, child12));
-        when(child2.getChildren()).thenAnswer((args)-> ImmutableList.<Node> of(child21));
+        when(rootNode.getChildren()).thenAnswer((args) -> ImmutableList.<Node> of(child1, child2));
+        when(child1.getChildren()).thenAnswer((args) -> ImmutableList.<Node> of(child11, child12));
+        when(child2.getChildren()).thenAnswer((args) -> ImmutableList.<Node> of(child21));
 
-        when(child11.getChildren()).thenAnswer((args)-> ImmutableList.<Node> of(childCommon));
-        when(child12.getChildren()).thenAnswer((args)-> ImmutableList.<Node> of(childCommon));
-        when(child21.getChildren()).thenAnswer((args)-> ImmutableList.<Node> of(childCommon));
+        when(child11.getChildren()).thenAnswer((args) -> ImmutableList.<Node> of(childCommon));
+        when(child12.getChildren()).thenAnswer((args) -> ImmutableList.<Node> of(childCommon));
+        when(child21.getChildren()).thenAnswer((args) -> ImmutableList.<Node> of(childCommon));
 
         when(rootNode.toString()).thenReturn("rootNode");
         when(child1.toString()).thenReturn("child1");

--- a/src/test/org/tensorics/core/tree/TreesExceptionTest.java
+++ b/src/test/org/tensorics/core/tree/TreesExceptionTest.java
@@ -77,9 +77,9 @@ public class TreesExceptionTest {
         child21 = mock(ExceptionHandlingNode.class);
         childCommon = mock(Node.class);
 
-        when(rootNode.getChildren()).thenAnswer((args)-> ImmutableList.<Node> of(child1, child2));
-        when(child1.getChildren()).thenAnswer((args)-> ImmutableList.<Node> of(child11, childCommon));
-        when(child2.getChildren()).thenAnswer((args)-> ImmutableList.<Node> of(child21, childCommon));
+        when(rootNode.getChildren()).thenAnswer((args) -> ImmutableList.<Node> of(child1, child2));
+        when(child1.getChildren()).thenAnswer((args) -> ImmutableList.<Node> of(child11, childCommon));
+        when(child2.getChildren()).thenAnswer((args) -> ImmutableList.<Node> of(child21, childCommon));
 
         when(rootNode.toString()).thenReturn("rootNode");
         when(child1.toString()).thenReturn("child1");

--- a/src/test/org/tensorics/core/tree/TreesTest.java
+++ b/src/test/org/tensorics/core/tree/TreesTest.java
@@ -64,10 +64,10 @@ public class TreesTest {
         child22 = mock(Node.class);
         child221 = mock(Node.class);
 
-        when(rootNode.getChildren()).thenAnswer((args)-> ImmutableList.<Node> of(child1, child2));
-        when(child1.getChildren()).thenAnswer((args)-> ImmutableList.<Node> of(child11, child12));
-        when(child2.getChildren()).thenAnswer((args)-> ImmutableList.<Node> of(child21, child22));
-        when(child22.getChildren()).thenAnswer((args)-> ImmutableList.<Node> of(child221));
+        when(rootNode.getChildren()).thenAnswer((args) -> ImmutableList.<Node> of(child1, child2));
+        when(child1.getChildren()).thenAnswer((args) -> ImmutableList.<Node> of(child11, child12));
+        when(child2.getChildren()).thenAnswer((args) -> ImmutableList.<Node> of(child21, child22));
+        when(child22.getChildren()).thenAnswer((args) -> ImmutableList.<Node> of(child221));
     }
 
     @Test
@@ -83,7 +83,8 @@ public class TreesTest {
     @Test
     public void testSubTreeContentFullTree() {
         List<Node> allNodes = Trees.subTreeContent(rootNode);
-        assertEquals(ImmutableList.of(child11, child12, child1, child21, child221, child22, child2, rootNode), allNodes);
+        assertEquals(ImmutableList.of(child11, child12, child1, child21, child221, child22, child2, rootNode),
+                allNodes);
     }
 
     @Test

--- a/src/test/org/tensorics/core/tree/walking/TreesFindNodeOfClassTest.java
+++ b/src/test/org/tensorics/core/tree/walking/TreesFindNodeOfClassTest.java
@@ -13,59 +13,59 @@ import org.tensorics.core.tree.domain.Node;
 
 public class TreesFindNodeOfClassTest {
 
-	@Test
-	public void findNodeOfExpressionClass() {
-		AnyExpression expr1 = new AnyExpression();
-		AnyExpression expr2 = new AnyExpression();
-		AnyMarkedExpression markedExpr1 = new AnyMarkedExpression();
-		AnyMarkedExpression markedExpr2 = new AnyMarkedExpression();
+    @Test
+    public void findNodeOfExpressionClass() {
+        AnyExpression expr1 = new AnyExpression();
+        AnyExpression expr2 = new AnyExpression();
+        AnyMarkedExpression markedExpr1 = new AnyMarkedExpression();
+        AnyMarkedExpression markedExpr2 = new AnyMarkedExpression();
 
-		Expression<?> group = new GroupExpression(Arrays.asList(expr1, expr2, markedExpr1, markedExpr2));
-		Set<AnyExpression> result = Trees.findNodesOfClass(group, AnyExpression.class);
-		Assertions.assertThat(result).containsOnly(expr1, expr2);
-	}
+        Expression<?> group = new GroupExpression(Arrays.asList(expr1, expr2, markedExpr1, markedExpr2));
+        Set<AnyExpression> result = Trees.findNodesOfClass(group, AnyExpression.class);
+        Assertions.assertThat(result).containsOnly(expr1, expr2);
+    }
 
-	@Test
-	public void findNodeOfMarkerClass() {
-		AnyExpression expr1 = new AnyExpression();
-		AnyExpression expr2 = new AnyExpression();
-		AnyMarkedExpression markedExpr1 = new AnyMarkedExpression();
-		AnyMarkedExpression markedExpr2 = new AnyMarkedExpression();
+    @Test
+    public void findNodeOfMarkerClass() {
+        AnyExpression expr1 = new AnyExpression();
+        AnyExpression expr2 = new AnyExpression();
+        AnyMarkedExpression markedExpr1 = new AnyMarkedExpression();
+        AnyMarkedExpression markedExpr2 = new AnyMarkedExpression();
 
-		Expression<?> group = new GroupExpression(Arrays.asList(expr1, expr2, markedExpr1, markedExpr2));
-		Set<Marker> result = Trees.findNodesOfClass(group, Marker.class);
-		Assertions.assertThat(result).containsOnly(markedExpr1, markedExpr2);
-	}
+        Expression<?> group = new GroupExpression(Arrays.asList(expr1, expr2, markedExpr1, markedExpr2));
+        Set<Marker> result = Trees.findNodesOfClass(group, Marker.class);
+        Assertions.assertThat(result).containsOnly(markedExpr1, markedExpr2);
+    }
 
-	private interface Marker {
-		/* Just a marker interface */
-	}
+    private interface Marker {
+        /* Just a marker interface */
+    }
 
-	private class AnyExpression extends AbstractDeferredExpression<Void> {
-		@Override
-		public List<? extends Node> getChildren() {
-			return Collections.emptyList();
-		}
-	}
+    private class AnyExpression extends AbstractDeferredExpression<Void> {
+        @Override
+        public List<? extends Node> getChildren() {
+            return Collections.emptyList();
+        }
+    }
 
-	private class AnyMarkedExpression extends AbstractDeferredExpression<Void> implements Marker {
-		@Override
-		public List<? extends Node> getChildren() {
-			return Collections.emptyList();
-		}
-	}
+    private class AnyMarkedExpression extends AbstractDeferredExpression<Void>implements Marker {
+        @Override
+        public List<? extends Node> getChildren() {
+            return Collections.emptyList();
+        }
+    }
 
-	private class GroupExpression extends AbstractDeferredExpression<Void> {
-		private final List<? extends Node> children;
+    private class GroupExpression extends AbstractDeferredExpression<Void> {
+        private final List<? extends Node> children;
 
-		public GroupExpression(List<? extends Node> children) {
-			this.children = children;
-		}
+        public GroupExpression(List<? extends Node> children) {
+            this.children = children;
+        }
 
-		@Override
-		public List<? extends Node> getChildren() {
-			return children;
-		}
-	}
+        @Override
+        public List<? extends Node> getChildren() {
+            return children;
+        }
+    }
 
 }

--- a/src/test/org/tensorics/incubate/function/DiscreteFunctionTest.java
+++ b/src/test/org/tensorics/incubate/function/DiscreteFunctionTest.java
@@ -35,6 +35,7 @@ public class DiscreteFunctionTest {
     private DiscreteFunction<Double, Double> functionToTest;
 
     private static final List<Double> VALUES = new ArrayList<>();
+
     static {
         VALUES.add(5.0);
         VALUES.add(4.9);


### PR DESCRIPTION
Proposal to introduce Scalar. Open questions to look at:
* What do you think about the ways to construct a scalar: Currently one has to write something like:
`sWithEmptyContext = ImmutableScalar.of(value);`
or
`sWithOtherContext = ImmutableScalar.of(value).withContext(coord1, coord2);`
... Or would be factory methods with 2 args and/or varargs be better?

What also will come with this extension (for the moment I think we will rather create a new change): How to treat equality between tensors? E.g. currently, the equals methods follow the same rules as usual: If not the same class, then they are not equal. However, probably a Scalar and a zerodimensional tensor should be equal as long as theyr shape and their content are equal, right?