### PR TITLE
Scanner for name repository is problematic when constants values are not unique

### DIFF
--- a/src/test/org/tensorics/core/util/names/ClasspathConstantScannerTest.java
+++ b/src/test/org/tensorics/core/util/names/ClasspathConstantScannerTest.java
@@ -7,30 +7,40 @@ package org.tensorics.core.util.names;
 import org.apache.log4j.BasicConfigurator;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.assertj.core.api.Assertions;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableSet;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class ClasspathConstantScannerTest {
 
     public static final String A_TEST_VALUE_TO_BE_FOUND = "aTestValueToBeFound";
 
+    public static final String DUPLICATE_VALUE_A = "SAME";
+    public static final String DUPLICATE_VALUE_B = "SAME";
+
     @BeforeClass
-    public static final void setUpBeforeClass() {
+    public static void setUpBeforeClass() {
         BasicConfigurator.configure();
         Logger.getRootLogger().setLevel(Level.INFO);
     }
 
     @Test
-    public void test() {
-        long start = System.nanoTime();
+    public void testConstantIsFound() {
         ClasspathConstantScanner scanner = new ClasspathConstantScanner(ImmutableSet.of("org.tensorics.core.util.names"));
         NameRepository nameRepo = scanner.scan();
-        long end = System.nanoTime();
-        System.out.println("Done in " + Double.valueOf((end - start) / 1000000) / 1e3 + " secs.");
-        Assertions.assertThat(nameRepo.nameFor(A_TEST_VALUE_TO_BE_FOUND)).isEqualTo("A_TEST_VALUE_TO_BE_FOUND");
+        assertThat(nameRepo.nameFor(A_TEST_VALUE_TO_BE_FOUND)).isEqualTo("A_TEST_VALUE_TO_BE_FOUND");
+    }
+
+    @Test
+    public void testDuplicateConstantEntry() {
+        ClasspathConstantScanner scanner = new ClasspathConstantScanner(ImmutableSet.of("org.tensorics.core.util.names"));
+        NameRepository nameRepo = scanner.scan();
+
+        assertThat(nameRepo.nameFor(DUPLICATE_VALUE_A)).isEqualTo("DUPLICATE_VALUE_A");
+        assertThat(nameRepo.nameFor(DUPLICATE_VALUE_B)).isEqualTo("DUPLICATE_VALUE_B");
     }
 
 }


### PR DESCRIPTION
Found out when building on Travis with jdk9. If the package scan finds, e.g., 2 constants with the same value, the key of the internal map will be the same overriding one of them..

How could we improve this? This pull request is just for not forgetting about this :)