### PR TITLE
Guava update..

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 jdk:
   - oraclejdk8
+  - oraclejdk9
 sudo: false
 before_install:
   - chmod +x ./gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ sourceCompatibility = JavaVersion.VERSION_1_8
 
 dependencies {
     compile 'org.jscience:jscience:4.3.1'
-    compile 'com.google.guava:guava:21.0'
+    compile 'com.google.guava:guava:25.1-jre'
     compile 'org.hamcrest:hamcrest-all:1.3'
     compile 'org.slf4j:slf4j-api:1.7.21'
 


### PR DESCRIPTION
In order for the scanning to work on jdk > 8 we need at least Guava 24.0... 
We have 3 options:
1. Ignore jdk > 8 (this will hit us during LS2)
2. Use Guava 25.1 (the latest)
3. Change the scanning method

Which one do you prefer? @michi42 @kaifox 

I'd go for the updating to 25, but we would have to check with the LumiServer other dependencies. Anyhow, LSA will most probably use Guava PRO, which is anyway a lower version and it works...