### PR TITLE
Optional Get

### DIFF
--- a/src/java/org/tensorics/core/tensor/ImmutableTensor.java
+++ b/src/java/org/tensorics/core/tensor/ImmutableTensor.java
@@ -158,7 +158,6 @@ public class ImmutableTensor<V> extends AbstractTensor<V> implements Mappable<V>
 
     private V findValueOrThrow(Position position) {
         requireNonNull(position, "position must not be null");
-        Positions.areDimensionsConsistentWithCoordinates(shape.dimensionSet(), position);
         V entry = findEntryOrNull(position);
         if (entry == null) {
             String message = "Entry for position '" + position + "' is not contained in this tensor.";

--- a/src/test/org/tensorics/core/tensor/lang/OptionalGetTest.java
+++ b/src/test/org/tensorics/core/tensor/lang/OptionalGetTest.java
@@ -1,0 +1,57 @@
+package org.tensorics.core.tensor.lang;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.tensorics.core.lang.Tensorics.at;
+import static org.tensorics.core.lang.Tensorics.from;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import org.junit.Test;
+import org.tensorics.core.lang.Tensorics;
+import org.tensorics.core.tensor.Tensor;
+
+public class OptionalGetTest {
+
+    private final Tensor<Double> tensor = Tensorics.<Double> builder(String.class, Integer.class)//
+            .put(at("a", 1), 1.0) //
+            .build();
+
+    @Test
+    public void wrongDimensionsThrowIllegalArgument() {
+        assertThrows(IllegalArgumentException.class, () -> from(tensor).get("a"));
+    }
+
+    @Test
+    public void optionalWrongDimensionsThrowIllegalArgument() {
+        assertThrows(IllegalArgumentException.class, () -> from(tensor).optional("a"));
+    }
+
+    @Test
+    public void rightDimensionsNonExistingThrowNoSuchElement() {
+        assertThrows(NoSuchElementException.class, () -> from(tensor).get("b", 1));
+    }
+    
+    @Test
+    public void optionalRightDimensionsNonExistingReturnsEmpty() {
+        Optional<Double> optional = from(tensor).optional("b", 1);
+        assertThat(optional).isEmpty();
+    }
+    
+    @Test
+    public void existingGetWorks() {
+        Double val = from(tensor).get("a", 1);
+        assertThat(val).isEqualTo(1.0);
+    }
+    
+    @Test
+    public void existingOptionalGetWorks() {
+        Optional<Double> val = from(tensor).optional("a", 1);
+        assertThat(val.get()).isEqualTo(1.0);
+    }
+    
+    
+
+    
+}


### PR DESCRIPTION
Hi guys,

if somebody has time to have a quick look ... this is just a (hopefully) simple extension to get an optional value from a tensor.

Something like
```
Optional<V> o = Tensorics.from(tensor).optional(c1, c1);
```

* First:  Is 'optional' a good name for the method? Or should it be something like 'optionalGet' or 'getOptional'?
* Secondly, I think this also replaces the existing somehow confusing 'either' construct, as one now could simply do `from(tensor).optional(c1,c2).orElse(some_value);`... Agreed?
* And finally, is the behaviour intuitive?
   * optional with value if position is contained
   * empty optional if position dimensions are compatible
   * IllegalArgumentException if dimensions of position are incompatible ...

Greetings

